### PR TITLE
Rename vex prefix to vx and update build paths

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,8 @@
 Business Source License 1.0
 License Grant
-Subject to the limitations and conditions below, you are granted a non-exclusive, worldwide, royalty-free license to use, copy, modify, and distribute VEXDB software.
+Subject to the limitations and conditions below, you are granted a non-exclusive, worldwide, royalty-free license to use, copy, modify, and distribute VXDB software.
 Usage Limitations
-You may use VEXDB under this license provided your use qualifies under the free usage criteria below:
+You may use VXDB under this license provided your use qualifies under the free usage criteria below:
 Development & Small Scale Use (Always Free)
 
 Development environments (testing, staging, CI/CD) - unlimited
@@ -26,8 +26,8 @@ Any managed service offerings or commercial redistribution
 
 Prohibited Uses Without Commercial License
 
-Managed service offerings (offering VEXDB as a service to third parties)
-Consulting services where VEXDB is the primary deliverable
+Managed service offerings (offering VXDB as a service to third parties)
+Consulting services where VXDB is the primary deliverable
 Embedding in commercial products sold to customers
 Production use exceeding the thresholds above
 
@@ -77,7 +77,7 @@ Advanced analytics and monitoring dashboards
 
 Competitive Protections
 Cloud Provider Restrictions
-Major cloud providers (AWS, Google, Azure, Alibaba) cannot offer VEXDB as a managed service without explicit partnership agreement.
+Major cloud providers (AWS, Google, Azure, Alibaba) cannot offer VXDB as a managed service without explicit partnership agreement.
 Modification Rights
 You may modify the software, but modified versions:
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-# VexDB Makefile
-# This Makefile provides convenient commands for building, testing, and deploying VexDB
+# VxDB Makefile
+# This Makefile provides convenient commands for building, testing, and deploying VxDB
 
 # Variables
 GO_VERSION := 1.21
 DOCKER_REGISTRY := ghcr.io
-IMAGE_NAME := vexdb
-NAMESPACE := vexdb
+IMAGE_NAME := vxdb
+NAMESPACE := vxdb
 KUBECONFIG := ~/.kube/config
 
 # Go variables
@@ -31,7 +31,7 @@ NC := \033[0m # No Color
 # Help target
 .PHONY: help
 help: ## Show this help message
-	@echo "$(CYAN)VexDB Development Commands$(NC)"
+	@echo "$(CYAN)VxDB Development Commands$(NC)"
 	@echo ""
 	@echo "$(GREEN)Development:$(NC)"
 	@awk 'BEGIN {FS = ":.*##"; printf "$(YELLOW)%-20s$(NC) %s\n", "Target", "Description"} /^[a-zA-Z_-]+:.*?##/ { printf "$(YELLOW)%-20s$(NC) %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -61,7 +61,7 @@ install: ## Install Go dependencies
 .PHONY: generate
 generate: ## Generate code from proto files
 	@echo "$(BLUE)Generating code from proto files...$(NC)"
-	protoc --go_out=. --go-grpc_out=. proto/vexdb.proto
+	protoc --go_out=. --go-grpc_out=. proto/vxdb.proto
 
 .PHONY: format
 format: ## Format Go code
@@ -88,29 +88,29 @@ security-scan: ## Run security scan
 .PHONY: build
 build: ## Build all services
 	@echo "$(BLUE)Building all services...$(NC)"
-	$(MAKE) build-vexinsert
-	$(MAKE) build-vexstorage
-	$(MAKE) build-vexsearch
+	$(MAKE) build-vxinsert
+	$(MAKE) build-vxstorage
+	$(MAKE) build-vxsearch
 
-.PHONY: build-vexinsert
-build-vexinsert: ## Build vexinsert service
-	@echo "$(BLUE)Building vexinsert service...$(NC)"
-	go build -o bin/vexinsert ./cmd/vexinsert
+.PHONY: build-vxinsert
+build-vxinsert: ## Build vxinsert service
+	@echo "$(BLUE)Building vxinsert service...$(NC)"
+	go build -o bin/vxinsert ./cmd/vxinsert
 
-.PHONY: build-vexstorage
-build-vexstorage: ## Build vexstorage service
-	@echo "$(BLUE)Building vexstorage service...$(NC)"
-	go build -o bin/vexstorage ./cmd/vexstorage
+.PHONY: build-vxstorage
+build-vxstorage: ## Build vxstorage service
+	@echo "$(BLUE)Building vxstorage service...$(NC)"
+	go build -o bin/vxstorage ./cmd/vxstorage
 
-.PHONY: build-vexsearch
-build-vexsearch: ## Build vexsearch service
-	@echo "$(BLUE)Building vexsearch service...$(NC)"
-	go build -o bin/vexsearch ./cmd/vexsearch
+.PHONY: build-vxsearch
+build-vxsearch: ## Build vxsearch service
+	@echo "$(BLUE)Building vxsearch service...$(NC)"
+	go build -o bin/vxsearch ./cmd/vxsearch
 
 .PHONY: build-all-platforms
 build-all-platforms: ## Build all services for all platforms
 	@echo "$(BLUE)Building all services for all platforms...$(NC)"
-	@for service in vexinsert vexstorage vexsearch; do \
+	@for service in vxinsert vxstorage vxsearch; do \
 		for os in linux darwin windows; do \
 			for arch in amd64 arm64; do \
 				if [ "$$os" == "windows" ]; then \
@@ -158,46 +158,46 @@ test-benchmark: ## Run benchmark tests
 .PHONY: docker-build
 docker-build: ## Build Docker images
 	@echo "$(BLUE)Building Docker images...$(NC)"
-	$(MAKE) docker-build-vexinsert
-	$(MAKE) docker-build-vexstorage
-	$(MAKE) docker-build-vexsearch
+	$(MAKE) docker-build-vxinsert
+	$(MAKE) docker-build-vxstorage
+	$(MAKE) docker-build-vxsearch
 
-.PHONY: docker-build-vexinsert
-docker-build-vexinsert: ## Build vexinsert Docker image
-	@echo "$(BLUE)Building vexinsert Docker image...$(NC)"
-	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexinsert:latest -f cmd/vexinsert/Dockerfile .
+.PHONY: docker-build-vxinsert
+docker-build-vxinsert: ## Build vxinsert Docker image
+	@echo "$(BLUE)Building vxinsert Docker image...$(NC)"
+	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxinsert:latest -f cmd/vxinsert/Dockerfile .
 
-.PHONY: docker-build-vexstorage
-docker-build-vexstorage: ## Build vexstorage Docker image
-	@echo "$(BLUE)Building vexstorage Docker image...$(NC)"
-	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexstorage:latest -f cmd/vexstorage/Dockerfile .
+.PHONY: docker-build-vxstorage
+docker-build-vxstorage: ## Build vxstorage Docker image
+	@echo "$(BLUE)Building vxstorage Docker image...$(NC)"
+	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxstorage:latest -f cmd/vxstorage/Dockerfile .
 
-.PHONY: docker-build-vexsearch
-docker-build-vexsearch: ## Build vexsearch Docker image
-	@echo "$(BLUE)Building vexsearch Docker image...$(NC)"
-	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexsearch:latest -f cmd/vexsearch/Dockerfile .
+.PHONY: docker-build-vxsearch
+docker-build-vxsearch: ## Build vxsearch Docker image
+	@echo "$(BLUE)Building vxsearch Docker image...$(NC)"
+	docker build -t $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxsearch:latest -f cmd/vxsearch/Dockerfile .
 
 .PHONY: docker-push
 docker-push: ## Push Docker images
 	@echo "$(BLUE)Pushing Docker images...$(NC)"
-	$(MAKE) docker-push-vexinsert
-	$(MAKE) docker-push-vexstorage
-	$(MAKE) docker-push-vexsearch
+	$(MAKE) docker-push-vxinsert
+	$(MAKE) docker-push-vxstorage
+	$(MAKE) docker-push-vxsearch
 
-.PHONY: docker-push-vexinsert
-docker-push-vexinsert: ## Push vexinsert Docker image
-	@echo "$(BLUE)Pushing vexinsert Docker image...$(NC)"
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexinsert:latest
+.PHONY: docker-push-vxinsert
+docker-push-vxinsert: ## Push vxinsert Docker image
+	@echo "$(BLUE)Pushing vxinsert Docker image...$(NC)"
+	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxinsert:latest
 
-.PHONY: docker-push-vexstorage
-docker-push-vexstorage: ## Push vexstorage Docker image
-	@echo "$(BLUE)Pushing vexstorage Docker image...$(NC)"
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexstorage:latest
+.PHONY: docker-push-vxstorage
+docker-push-vxstorage: ## Push vxstorage Docker image
+	@echo "$(BLUE)Pushing vxstorage Docker image...$(NC)"
+	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxstorage:latest
 
-.PHONY: docker-push-vexsearch
-docker-push-vexsearch: ## Push vexsearch Docker image
-	@echo "$(BLUE)Pushing vexsearch Docker image...$(NC)"
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexsearch:latest
+.PHONY: docker-push-vxsearch
+docker-push-vxsearch: ## Push vxsearch Docker image
+	@echo "$(BLUE)Pushing vxsearch Docker image...$(NC)"
+	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxsearch:latest
 
 .PHONY: docker-compose-up
 docker-compose-up: ## Start services with Docker Compose
@@ -218,24 +218,24 @@ docker-compose-logs: ## Show Docker Compose logs
 .PHONY: k8s-deploy
 k8s-deploy: ## Deploy to Kubernetes
 	@echo "$(BLUE)Deploying to Kubernetes...$(NC)"
-	kubectl apply -f kubernetes/vexdb-deployment.yaml
+	kubectl apply -f kubernetes/vxdb-deployment.yaml
 
 .PHONY: k8s-delete
 k8s-delete: ## Delete from Kubernetes
 	@echo "$(BLUE)Deleting from Kubernetes...$(NC)"
-	kubectl delete -f kubernetes/vexdb-deployment.yaml
+	kubectl delete -f kubernetes/vxdb-deployment.yaml
 
 .PHONY: k8s-logs
 k8s-logs: ## Show Kubernetes logs
 	@echo "$(BLUE)Showing Kubernetes logs...$(NC)"
-	kubectl logs -f -n $(NAMESPACE) deployment/vexinsert-deployment
+	kubectl logs -f -n $(NAMESPACE) deployment/vxinsert-deployment
 
 .PHONY: k8s-port-forward
 k8s-port-forward: ## Port forward Kubernetes services
 	@echo "$(BLUE)Port forwarding Kubernetes services...$(NC)"
-	kubectl port-forward -n $(NAMESPACE) service/vexinsert-service 8080:8080 &
-	kubectl port-forward -n $(NAMESPACE) service/vexstorage-service 8082:8082 &
-	kubectl port-forward -n $(NAMESPACE) service/vexsearch-service 8083:8083 &
+	kubectl port-forward -n $(NAMESPACE) service/vxinsert-service 8080:8080 &
+	kubectl port-forward -n $(NAMESPACE) service/vxstorage-service 8082:8082 &
+	kubectl port-forward -n $(NAMESPACE) service/vxsearch-service 8083:8083 &
 
 .PHONY: k8s-status
 k8s-status: ## Show Kubernetes status
@@ -266,9 +266,9 @@ clean: ## Clean build artifacts
 .PHONY: clean-docker
 clean-docker: ## Clean Docker images
 	@echo "$(BLUE)Cleaning Docker images...$(NC)"
-	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexinsert:latest || true
-	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexstorage:latest || true
-	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vexsearch:latest || true
+	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxinsert:latest || true
+	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxstorage:latest || true
+	docker rmi $(DOCKER_REGISTRY)/$(IMAGE_NAME)-vxsearch:latest || true
 
 .PHONY: clean-k8s
 clean-k8s: ## Clean Kubernetes resources
@@ -288,9 +288,9 @@ dev-up: ## Start development environment
 	@echo "$(BLUE)Starting development environment...$(NC)"
 	$(MAKE) docker-compose-up
 	@echo "$(GREEN)Development environment started!$(NC)"
-	@echo "$(YELLOW)VexInsert API: http://localhost:8080$(NC)"
-	@echo "$(YELLOW)VexStorage API: http://localhost:8082$(NC)"
-	@echo "$(YELLOW)VexSearch API: http://localhost:8083$(NC)"
+	@echo "$(YELLOW)VxInsert API: http://localhost:8080$(NC)"
+	@echo "$(YELLOW)VxStorage API: http://localhost:8082$(NC)"
+	@echo "$(YELLOW)VxSearch API: http://localhost:8083$(NC)"
 	@echo "$(YELLOW)Metrics: http://localhost:9090$(NC)"
 	@echo "$(YELLOW)Grafana: http://localhost:3000$(NC)"
 	@echo "$(YELLOW)Jaeger: http://localhost:16686$(NC)"
@@ -339,7 +339,7 @@ release: ## Create a new release
 # Utility targets
 .PHONY: version
 version: ## Show version information
-	@echo "$(BLUE)VexDB Version Information$(NC)"
+	@echo "$(BLUE)VxDB Version Information$(NC)"
 	@echo "$(YELLOW)Go Version:$(NC) $(shell go version)"
 	@echo "$(YELLOW)Git Commit:$(NC) $(shell git rev-parse HEAD)"
 	@echo "$(YELLOW)Git Branch:$(NC) $(shell git rev-parse --abbrev-ref HEAD)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# VexDB
+# VxDB
 
-VexDB is a distributed, high-throughput streaming vector database designed for real-time similarity search and scalable ingestion. It features a shared-nothing architecture with three core services: ingestion (`vxinsert`), storage (`vxstorage`), and query coordination (`vxsearch`).
+VxDB is a distributed, high-throughput streaming vector database designed for real-time similarity search and scalable ingestion. It features a shared-nothing architecture with three core services: ingestion (`vxinsert`), storage (`vxstorage`), and query coordination (`vxsearch`).
 
 ## Features
 - **Sub-second write latency** and immediate searchability
@@ -15,7 +15,7 @@ VexDB is a distributed, high-throughput streaming vector database designed for r
 ## Architecture
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                        VexDB Cluster                        │
+│                        VxDB Cluster                        │
 ├─────────────────────────────────────────────────────────────┤
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
 │  │  vxinsert  │  │  vxinsert  │  │  vxinsert  │          │
@@ -65,21 +65,21 @@ VexDB is a distributed, high-throughput streaming vector database designed for r
 ## Deployment
 
 ### Docker Compose
-VexDB provides a `docker-compose.yml` for local development and testing:
+VxDB provides a `docker-compose.yml` for local development and testing:
 
 ```sh
 docker-compose up --build
 ```
 
 This will start:
-- `vexinsert` (ingestion)
-- `vexstorage` (storage/index)
-- `vexsearch` (query)
+- `vxinsert` (ingestion)
+- `vxstorage` (storage/index)
+- `vxsearch` (query)
 - `prometheus`, `grafana`, `jaeger` (monitoring)
 - `redis` (optional), `nginx` (optional)
 
 ### Configuration
-Service configs are in `configs/` (e.g., `vexinsert-production.yaml`).
+Service configs are in `configs/` (e.g., `vxinsert-production.yaml`).
 
 ## API Examples
 
@@ -135,4 +135,4 @@ go test -tags integration ./...
 
 ---
 
-© 2025 VexDB Development Team
+© 2025 VxDB Development Team

--- a/SPEC_RFC.md
+++ b/SPEC_RFC.md
@@ -1,14 +1,14 @@
-# VexDB: Streaming Vector Database System Specification
+# VxDB: Streaming Vector Database System Specification
 **Version:** 1.0  
 **Status:** Draft  
-**Authors:** VexDB Development Team  
+**Authors:** VxDB Development Team  
 **Date:** January 2025
 
 ---
 
 ## Abstract
 
-VexDB is a distributed vector database system optimized for high-throughput streaming ingestion and low-latency similarity search. The system employs a shared-nothing architecture with three independent services: vxinsert (ingestion), vxsearch (query coordination), and vxstorage (storage and indexing). VexDB prioritizes write performance through append-only segment storage and maintains search quality via unified IVF (Inverted File) indices with hybrid update strategies.
+VxDB is a distributed vector database system optimized for high-throughput streaming ingestion and low-latency similarity search. The system employs a shared-nothing architecture with three independent services: vxinsert (ingestion), vxsearch (query coordination), and vxstorage (storage and indexing). VxDB prioritizes write performance through append-only segment storage and maintains search quality via unified IVF (Inverted File) indices with hybrid update strategies.
 
 Key design principles include protocol compatibility for seamless integration with existing data infrastructure, deterministic replication for operational simplicity, and configurable performance tuning to accommodate diverse workload requirements.
 
@@ -37,7 +37,7 @@ The demand for real-time vector similarity search in applications such as recomm
 
 ### 1.3 System Overview
 
-VexDB implements a three-tier architecture where each service operates independently:
+VxDB implements a three-tier architecture where each service operates independently:
 
 - **vxinsert**: Multi-protocol ingestion layer with streaming optimization
 - **vxstorage**: Distributed storage engine with unified vector indexing
@@ -53,7 +53,7 @@ The system employs fixed cluster assignment for predictable routing, determinist
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                        VexDB Cluster                        │
+│                        VxDB Cluster                        │
 ├─────────────────────────────────────────────────────────────┤
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
 │  │  vxinsert  │  │  vxinsert  │  │  vxinsert  │          │
@@ -136,7 +136,7 @@ Content-Type: application/json
 
 **Kafka Connect Compatibility:**
 ```
-connector.class=VexDBSinkConnector
+connector.class=VxDBSinkConnector
 topics=embeddings
 vector.field=embedding
 metadata.fields=id,timestamp,source
@@ -216,9 +216,9 @@ vxinsert:
 ```
 /data/node_id/
 ├── segments/
-│   ├── cluster_001_seg_001.vex
-│   ├── cluster_001_seg_002.vex
-│   └── cluster_002_seg_001.vex
+│   ├── cluster_001_seg_001.vx
+│   ├── cluster_001_seg_002.vx
+│   └── cluster_002_seg_001.vx
 ├── indices/
 │   ├── ivf_snapshot_v123.idx
 │   └── ivf_wal.log
@@ -290,7 +290,7 @@ Query Vector Input
 ```yaml
 vxstorage:
   storage:
-    data_directory: "/var/lib/vexdb"
+    data_directory: "/var/lib/vxdb"
     vectors_per_segment: 10000
     memory_buffer_size: "8MB"
     
@@ -422,7 +422,7 @@ service VectorSearch {
 **Binary Layout:**
 ```
 Segment Header (256 bytes)
-├── Magic Number (8 bytes): "VEXSEG01"
+├── Magic Number (8 bytes): "VXSEG01"
 ├── Vector Count (8 bytes)
 ├── Vector Dimension (4 bytes)
 ├── Metadata Size (8 bytes)
@@ -499,7 +499,7 @@ message SearchRequest {
 **WebSocket Protocol:**
 ```
 Connection: ws://vxinsert:8080/stream
-Subprotocol: vexdb-v1
+Subprotocol: vxdb-v1
 
 Message Types:
 - vector_insert: Single vector ingestion
@@ -515,14 +515,14 @@ Error Handling:
 **Kafka Connect Integration:**
 ```json
 {
-  "connector.class": "io.vexdb.connect.VexDBSinkConnector",
+  "connector.class": "io.vxdb.connect.VxDBSinkConnector",
   "tasks.max": "1",
   "topics": "vectors",
-  "vexdb.endpoints": "vxinsert-1:8080,vxinsert-2:8080",
-  "vexdb.vector.field": "embedding",
-  "vexdb.metadata.fields": "id,timestamp,category",
-  "vexdb.batch.size": "1000",
-  "vexdb.retry.attempts": "3"
+  "vxdb.endpoints": "vxinsert-1:8080,vxinsert-2:8080",
+  "vxdb.vector.field": "embedding",
+  "vxdb.metadata.fields": "id,timestamp,category",
+  "vxdb.batch.size": "1000",
+  "vxdb.retry.attempts": "3"
 }
 ```
 
@@ -535,7 +535,7 @@ Error Handling:
 **Static Topology Definition:**
 ```yaml
 cluster:
-  name: "vexdb-production"
+  name: "vxdb-production"
   total_clusters: 1024
   replication_factor: 2
   
@@ -555,12 +555,12 @@ services:
         host: "10.0.2.10"
         port: 8090
         cluster_ranges: ["0-255", "512-767"]    # Primary + replica
-        data_directory: "/var/lib/vexdb"
+        data_directory: "/var/lib/vxdb"
       - id: "storage-2"
         host: "10.0.2.11"
         port: 8090  
         cluster_ranges: ["256-511", "768-1023"]
-        data_directory: "/var/lib/vexdb"
+        data_directory: "/var/lib/vxdb"
         
   vxsearch:
     instances:
@@ -609,12 +609,12 @@ vxinsert:
 GET /metrics (Prometheus format)
 
 Key Metrics:
-- vexdb_vectors_ingested_total
-- vexdb_queries_executed_total  
-- vexdb_query_duration_seconds
-- vexdb_memory_buffer_utilization
-- vexdb_segment_count_total
-- vexdb_ivf_rebuild_duration_seconds
+- vxdb_vectors_ingested_total
+- vxdb_queries_executed_total  
+- vxdb_query_duration_seconds
+- vxdb_memory_buffer_utilization
+- vxdb_segment_count_total
+- vxdb_ivf_rebuild_duration_seconds
 ```
 
 **Health Checks:**
@@ -711,4 +711,4 @@ Response: {"ready": true|false}
 - OAuth 2.0 Authorization Framework (RFC 6749)
 - Advanced Encryption Standard (AES) (FIPS 197)
 
---. For the latest version, consult the official VexDB documentation repository.*
+--. For the latest version, consult the official VxDB documentation repository.*

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,9 +1,9 @@
-# VexDB Implementation Task List
+# VxDB Implementation Task List
 
 ## Phase 1: Core Infrastructure (4-6 weeks)
 
 ### 1.1 Project Setup and Foundations
-- [ ] **Initialize Go modules** for each service (vexinsert, vexstorage, vexsearch)
+- [ ] **Initialize Go modules** for each service (vxinsert, vxstorage, vxsearch)
 - [ ] **Setup project structure** with shared libraries for common types
 - [ ] **Define core data structures** (Vector, Metadata, ClusterConfig)
 - [ ] **Implement configuration management** using YAML/JSON config files
@@ -33,7 +33,7 @@ type ClusterConfig struct {
 - [ ] **Build configuration validation** and error handling
 - [ ] **Setup configuration hot-reload** (optional, for development)
 
-## Phase 2: vexstorage - Storage Engine (6-8 weeks)
+## Phase 2: vxstorage - Storage Engine (6-8 weeks)
 
 ### 2.1 Segment Storage Implementation
 - [ ] **Design segment file format** with binary layout specification
@@ -101,7 +101,7 @@ type ClusterConfig struct {
 - [ ] **Build graceful shutdown** with connection draining
 - [ ] **Create storage service main application**
 
-## Phase 3: vexinsert - Ingestion Service (4-5 weeks)
+## Phase 3: vxinsert - Ingestion Service (4-5 weeks)
 
 ### 3.1 Multi-Protocol Framework
 - [ ] **Design protocol adapter interface**
@@ -152,7 +152,7 @@ type ProtocolAdapter interface {
 - [ ] **Create Redis command handlers** (VECTOR.ADD, VECTOR.MADD)
 - [ ] **Add Redis-compatible error responses**
 
-## Phase 4: vexsearch - Query Coordination (3-4 weeks)
+## Phase 4: vxsearch - Query Coordination (3-4 weeks)
 
 ### 4.1 Query Planning Engine
 - [ ] **Implement query vector analysis** for cluster determination
@@ -276,7 +276,7 @@ type ProtocolAdapter interface {
 4. Integration testing and performance validation
 
 **Parallel Development Opportunities**:
-- vexinsert and vexsearch can be developed concurrently after vexstorage core is complete
+- vxinsert and vxsearch can be developed concurrently after vxstorage core is complete
 - Protocol adapters can be implemented independently
 - Testing and tooling can be developed alongside core features
 

--- a/cmd/vxinsert/Dockerfile
+++ b/cmd/vxinsert/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for VexDB Insert Service
+# Multi-stage build for VxDB Insert Service
 # Stage 1: Builder
 FROM golang:1.21-alpine AS builder
 
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vexinsert ./cmd/vexinsert
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vxinsert ./cmd/vxinsert
 
 # Stage 2: Runtime
 FROM alpine:3.19
@@ -27,28 +27,28 @@ FROM alpine:3.19
 RUN apk --no-cache add ca-certificates tzdata curl
 
 # Create non-root user
-RUN addgroup -g 1000 -S vexdb && \
-    adduser -u 1000 -S vexdb -G vexdb
+RUN addgroup -g 1000 -S vxdb && \
+    adduser -u 1000 -S vxdb -G vxdb
 
 # Create directories
-RUN mkdir -p /var/lib/vexdb/data /var/lib/vexdb/wal /var/lib/vexdb/snapshots /var/lib/vexdb/buffer /var/lib/vexdb/temp /var/log/vexdb /etc/vexdb/certs && \
-    chown -R vexdb:vexdb /var/lib/vexdb /var/log/vexdb /etc/vexdb
+RUN mkdir -p /var/lib/vxdb/data /var/lib/vxdb/wal /var/lib/vxdb/snapshots /var/lib/vxdb/buffer /var/lib/vxdb/temp /var/log/vxdb /etc/vxdb/certs && \
+    chown -R vxdb:vxdb /var/lib/vxdb /var/log/vxdb /etc/vxdb
 
 # Set working directory
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/vexinsert .
+COPY --from=builder /app/vxinsert .
 
 # Copy configuration files
-COPY --chown=vexdb:vexdb configs/vexinsert-production.yaml /etc/vexdb/config.yaml
+COPY --chown=vxdb:vxdb configs/vxinsert-production.yaml /etc/vxdb/config.yaml
 
 # Copy health check script
-COPY --chown=vexdb:vexdb scripts/health-check.sh /usr/local/bin/health-check.sh
+COPY --chown=vxdb:vxdb scripts/health-check.sh /usr/local/bin/health-check.sh
 RUN chmod +x /usr/local/bin/health-check.sh
 
 # Switch to non-root user
-USER vexdb
+USER vxdb
 
 # Expose ports
 EXPOSE 8080 9091 9092 8081 9093 6379 7946 7947
@@ -59,7 +59,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Set environment variables
 ENV GIN_MODE=release
-ENV VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+ENV VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
 
 # Run the application
-CMD ["./vexinsert", "--config", "/etc/vexdb/config.yaml"]
+CMD ["./vxinsert", "--config", "/etc/vxdb/config.yaml"]

--- a/cmd/vxinsert/main.go
+++ b/cmd/vxinsert/main.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )
@@ -43,7 +43,7 @@ func (s *insertServer) handleInsert(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	var configPath string
-	flag.StringVar(&configPath, "config", "configs/vexinsert-production.yaml", "Path to configuration file")
+	flag.StringVar(&configPath, "config", "configs/vxinsert-production.yaml", "Path to configuration file")
 	flag.Parse()
 
 	logger, err := logging.NewLogger()

--- a/cmd/vxsearch/Dockerfile
+++ b/cmd/vxsearch/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for VexDB Search Service
+# Multi-stage build for VxDB Search Service
 # Stage 1: Builder
 FROM golang:1.21-alpine AS builder
 
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vexsearch ./cmd/vexsearch
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vxsearch ./cmd/vxsearch
 
 # Stage 2: Runtime
 FROM alpine:3.19
@@ -27,32 +27,32 @@ FROM alpine:3.19
 RUN apk --no-cache add ca-certificates tzdata curl
 
 # Create non-root user
-RUN addgroup -g 1000 -S vexdb && \
-    adduser -u 1000 -S vexdb -G vexdb
+RUN addgroup -g 1000 -S vxdb && \
+    adduser -u 1000 -S vxdb -G vxdb
 
 # Create directories
-RUN mkdir -p /var/lib/vexdb/data /var/lib/vexdb/wal /var/lib/vexdb/snapshots /var/lib/vexdb/cache /var/log/vexdb /etc/vexdb/certs && \
-    chown -R vexdb:vexdb /var/lib/vexdb /var/log/vexdb /etc/vexdb
+RUN mkdir -p /var/lib/vxdb/data /var/lib/vxdb/wal /var/lib/vxdb/snapshots /var/lib/vxdb/cache /var/log/vxdb /etc/vxdb/certs && \
+    chown -R vxdb:vxdb /var/lib/vxdb /var/log/vxdb /etc/vxdb
 
 # Set working directory
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/vexsearch .
+COPY --from=builder /app/vxsearch .
 
 # Copy configuration files
-COPY --chown=vexdb:vexdb configs/vexsearch-production.yaml /etc/vexdb/config.yaml
+COPY --chown=vxdb:vxdb configs/vxsearch-production.yaml /etc/vxdb/config.yaml
 
 # Copy health check script
-COPY --chown=vexdb:vexdb scripts/health-check.sh /usr/local/bin/health-check.sh
+COPY --chown=vxdb:vxdb scripts/health-check.sh /usr/local/bin/health-check.sh
 RUN chmod +x /usr/local/bin/health-check.sh
 
 # Copy cache management script
-COPY --chown=vexdb:vexdb scripts/cache-management.sh /usr/local/bin/cache-management.sh
+COPY --chown=vxdb:vxdb scripts/cache-management.sh /usr/local/bin/cache-management.sh
 RUN chmod +x /usr/local/bin/cache-management.sh
 
 # Switch to non-root user
-USER vexdb
+USER vxdb
 
 # Expose ports
 EXPOSE 8083 9097 9098 9099 7950 7951
@@ -63,7 +63,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Set environment variables
 ENV GIN_MODE=release
-ENV VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+ENV VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
 
 # Run the application
-CMD ["./vexsearch", "--config", "/etc/vexdb/config.yaml"]
+CMD ["./vxsearch", "--config", "/etc/vxdb/config.yaml"]

--- a/cmd/vxsearch/main.go
+++ b/cmd/vxsearch/main.go
@@ -9,12 +9,12 @@ import (
 	"syscall"
 	"time"
 
-	logging2 "vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	searchconfig "vexdb/internal/search/config"
-	"vexdb/internal/search/server"
-	"vexdb/internal/search/service"
-	"vexdb/internal/storage/search"
+	logging2 "vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	searchconfig "vxdb/internal/search/config"
+	"vxdb/internal/search/server"
+	"vxdb/internal/search/service"
+	"vxdb/internal/storage/search"
 
 	"gopkg.in/yaml.v2"
 
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	var configPath string
-	flag.StringVar(&configPath, "config", "configs/vexsearch-production.yaml", "Path to configuration file")
+	flag.StringVar(&configPath, "config", "configs/vxsearch-production.yaml", "Path to configuration file")
 	flag.Parse()
 
 	// Initialize logger
@@ -33,7 +33,7 @@ func main() {
 	}
 	defer logger.Sync()
 
-	logger.Info("Starting VexDB Search Service", zap.String("config", configPath))
+	logger.Info("Starting VxDB Search Service", zap.String("config", configPath))
 
 	// Load configuration
 	searchConfig, err := loadConfig(configPath)
@@ -78,7 +78,7 @@ func main() {
 		logger.Fatal("Failed to start services", zap.Error(err))
 	}
 
-	logger.Info("VexDB Search Service started successfully")
+	logger.Info("VxDB Search Service started successfully")
 
 	// Set up signal handling
 	sigChan := make(chan os.Signal, 1)
@@ -86,7 +86,7 @@ func main() {
 
 	// Wait for shutdown signal
 	<-sigChan
-	logger.Info("Shutting down VexDB Search Service...")
+	logger.Info("Shutting down VxDB Search Service...")
 
 	// Graceful shutdown
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -96,7 +96,7 @@ func main() {
 		logger.Error("Error during shutdown", zap.Error(err))
 	}
 
-	logger.Info("VexDB Search Service stopped")
+	logger.Info("VxDB Search Service stopped")
 }
 
 // loadConfig loads the search service configuration from a YAML file

--- a/cmd/vxstorage/Dockerfile
+++ b/cmd/vxstorage/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for VexDB Storage Service
+# Multi-stage build for VxDB Storage Service
 # Stage 1: Builder
 FROM golang:1.21-alpine AS builder
 
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vexstorage ./cmd/vexstorage
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o vxstorage ./cmd/vxstorage
 
 # Stage 2: Runtime
 FROM alpine:3.19
@@ -27,36 +27,36 @@ FROM alpine:3.19
 RUN apk --no-cache add ca-certificates tzdata curl lz4-dev
 
 # Create non-root user
-RUN addgroup -g 1000 -S vexdb && \
-    adduser -u 1000 -S vexdb -G vexdb
+RUN addgroup -g 1000 -S vxdb && \
+    adduser -u 1000 -S vxdb -G vxdb
 
 # Create directories
-RUN mkdir -p /var/lib/vexdb/data /var/lib/vexdb/wal /var/lib/vexdb/snapshots /var/lib/vexdb/storage /var/lib/vexdb/temp /var/lib/vexdb/manifest /var/lib/vexdb/backups /var/log/vexdb /etc/vexdb/certs && \
-    chown -R vexdb:vexdb /var/lib/vexdb /var/log/vexdb /etc/vexdb
+RUN mkdir -p /var/lib/vxdb/data /var/lib/vxdb/wal /var/lib/vxdb/snapshots /var/lib/vxdb/storage /var/lib/vxdb/temp /var/lib/vxdb/manifest /var/lib/vxdb/backups /var/log/vxdb /etc/vxdb/certs && \
+    chown -R vxdb:vxdb /var/lib/vxdb /var/log/vxdb /etc/vxdb
 
 # Set working directory
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/vexstorage .
+COPY --from=builder /app/vxstorage .
 
 # Copy configuration files
-COPY --chown=vexdb:vexdb configs/vexstorage-production.yaml /etc/vexdb/config.yaml
+COPY --chown=vxdb:vxdb configs/vxstorage-production.yaml /etc/vxdb/config.yaml
 
 # Copy health check script
-COPY --chown=vexdb:vexdb scripts/health-check.sh /usr/local/bin/health-check.sh
+COPY --chown=vxdb:vxdb scripts/health-check.sh /usr/local/bin/health-check.sh
 RUN chmod +x /usr/local/bin/health-check.sh
 
 # Copy backup script
-COPY --chown=vexdb:vexdb scripts/backup.sh /usr/local/bin/backup.sh
+COPY --chown=vxdb:vxdb scripts/backup.sh /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/backup.sh
 
 # Copy maintenance script
-COPY --chown=vexdb:vexdb scripts/maintenance.sh /usr/local/bin/maintenance.sh
+COPY --chown=vxdb:vxdb scripts/maintenance.sh /usr/local/bin/maintenance.sh
 RUN chmod +x /usr/local/bin/maintenance.sh
 
 # Switch to non-root user
-USER vexdb
+USER vxdb
 
 # Expose ports
 EXPOSE 8082 9094 9095 9096 7948 7949
@@ -67,7 +67,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Set environment variables
 ENV GIN_MODE=release
-ENV VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+ENV VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
 
 # Run the application
-CMD ["./vexstorage", "--config", "/etc/vexdb/config.yaml"]
+CMD ["./vxstorage", "--config", "/etc/vxdb/config.yaml"]

--- a/cmd/vxstorage/main.go
+++ b/cmd/vxstorage/main.go
@@ -7,17 +7,17 @@ import (
 	"syscall"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage"
 
 	"go.uber.org/zap"
 )
 
 func main() {
 	var configPath string
-	flag.StringVar(&configPath, "config", "configs/vexstorage-production.yaml", "Path to configuration file")
+	flag.StringVar(&configPath, "config", "configs/vxstorage-production.yaml", "Path to configuration file")
 	flag.Parse()
 
 	logger, err := logging.NewLogger()

--- a/configs/vxinsert-production.yaml
+++ b/configs/vxinsert-production.yaml
@@ -1,4 +1,4 @@
-# VexDB Insert Service Production Configuration
+# VxDB Insert Service Production Configuration
 # This configuration is optimized for production environments
 
 # Server configuration
@@ -17,7 +17,7 @@ logging:
   format: "json"  # json, console
   output: "stdout"  # stdout, stderr, or file path
   file:
-    path: "/var/log/vexdb/vexinsert.log"
+    path: "/var/log/vxdb/vxinsert.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days
@@ -39,7 +39,7 @@ metrics:
   host: "0.0.0.0"
   port: 9091
   path: "/metrics"
-  namespace: "vexdb"
+  namespace: "vxdb"
   subsystem: "insert"
   buckets: [0.001, 0.01, 0.1, 1.0, 10.0, 60.0]
   enable_profiling: false
@@ -48,7 +48,7 @@ metrics:
 # Tracing configuration
 tracing:
   enabled: true
-  service_name: "vexinsert"
+  service_name: "vxinsert"
   endpoint: "http://jaeger:14268/api/traces"
   sampling_rate: 0.1  # 10% sampling in production
   batch_size: 512
@@ -85,11 +85,11 @@ dashboard:
 
 # Cluster configuration
 cluster:
-  name: "vexdb-cluster"
+  name: "vxdb-cluster"
   node_id: ""  # Auto-generated if empty
-  data_dir: "/var/lib/vexdb/data"
-  wal_dir: "/var/lib/vexdb/wal"
-  snapshot_dir: "/var/lib/vexdb/snapshots"
+  data_dir: "/var/lib/vxdb/data"
+  wal_dir: "/var/lib/vxdb/wal"
+  snapshot_dir: "/var/lib/vxdb/snapshots"
   join: []  # List of existing nodes to join
   bootstrap_expect: 3  # Expected number of nodes in cluster
   retry_join:
@@ -145,9 +145,9 @@ protocols:
     max_header_bytes: 1048576  # 1MB
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexinsert.crt"
-      key_file: "/etc/vexdb/certs/vexinsert.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxinsert.crt"
+      key_file: "/etc/vxdb/certs/vxinsert.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -188,9 +188,9 @@ protocols:
     enable_compression: true
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexinsert.crt"
-      key_file: "/etc/vexdb/certs/vexinsert.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxinsert.crt"
+      key_file: "/etc/vxdb/certs/vxinsert.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -213,9 +213,9 @@ protocols:
     connection_timeout: 30s
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexinsert.crt"
-      key_file: "/etc/vexdb/certs/vexinsert.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxinsert.crt"
+      key_file: "/etc/vxdb/certs/vxinsert.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -249,9 +249,9 @@ protocols:
     tcp_keepalive: 300s
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexinsert.crt"
-      key_file: "/etc/vexdb/certs/vexinsert.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxinsert.crt"
+      key_file: "/etc/vxdb/certs/vxinsert.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -325,8 +325,8 @@ auth:
     secret: ""  # JWT secret key
     algorithm: "HS256"
     expiration: 24h
-    issuer: "vexdb"
-    audience: "vexdb-clients"
+    issuer: "vxdb"
+    audience: "vxdb-clients"
   rate_limit:
     enabled: true
     requests_per_second: 1000
@@ -347,7 +347,7 @@ buffer:
     level: 6
   persistence:
     enabled: true
-    path: "/var/lib/vexdb/buffer"
+    path: "/var/lib/vxdb/buffer"
     sync_interval: 5s
     max_file_size: 104857600  # 100MB
     max_files: 10
@@ -423,16 +423,16 @@ performance:
   mutex_profile: false
   trace_profile: false
   profile_duration: 30s
-  profile_path: "/var/log/vexdb/profile"
+  profile_path: "/var/log/vxdb/profile"
 
 # Security configuration
 security:
   enabled: true
   tls:
     enabled: true
-    cert_file: "/etc/vexdb/certs/vexinsert.crt"
-    key_file: "/etc/vexdb/certs/vexinsert.key"
-    ca_file: "/etc/vexdb/certs/ca.crt"
+    cert_file: "/etc/vxdb/certs/vxinsert.crt"
+    key_file: "/etc/vxdb/certs/vxinsert.key"
+    ca_file: "/etc/vxdb/certs/ca.crt"
     client_auth: false
     min_version: "1.2"
     max_version: "1.3"
@@ -441,10 +441,10 @@ security:
   encryption:
     enabled: false
     algorithm: "aes-256-gcm"
-    key_file: "/etc/vexdb/encryption.key"
+    key_file: "/etc/vxdb/encryption.key"
   audit:
     enabled: true
-    log_file: "/var/log/vexdb/audit.log"
+    log_file: "/var/log/vxdb/audit.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days

--- a/configs/vxsearch-production.yaml
+++ b/configs/vxsearch-production.yaml
@@ -1,4 +1,4 @@
-# VexDB Search Service Production Configuration
+# VxDB Search Service Production Configuration
 # This configuration is optimized for production environments
 
 # Server configuration
@@ -17,7 +17,7 @@ logging:
   format: "json"  # json, console
   output: "stdout"  # stdout, stderr, or file path
   file:
-    path: "/var/log/vexdb/vexsearch.log"
+    path: "/var/log/vxdb/vxsearch.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days
@@ -39,7 +39,7 @@ metrics:
   host: "0.0.0.0"
   port: 9097
   path: "/metrics"
-  namespace: "vexdb"
+  namespace: "vxdb"
   subsystem: "search"
   buckets: [0.001, 0.01, 0.1, 1.0, 10.0, 60.0]
   enable_profiling: false
@@ -48,7 +48,7 @@ metrics:
 # Tracing configuration
 tracing:
   enabled: true
-  service_name: "vexsearch"
+  service_name: "vxsearch"
   endpoint: "http://jaeger:14268/api/traces"
   sampling_rate: 0.1  # 10% sampling in production
   batch_size: 512
@@ -85,11 +85,11 @@ dashboard:
 
 # Cluster configuration
 cluster:
-  name: "vexdb-cluster"
+  name: "vxdb-cluster"
   node_id: ""  # Auto-generated if empty
-  data_dir: "/var/lib/vexdb/data"
-  wal_dir: "/var/lib/vexdb/wal"
-  snapshot_dir: "/var/lib/vexdb/snapshots"
+  data_dir: "/var/lib/vxdb/data"
+  wal_dir: "/var/lib/vxdb/wal"
+  snapshot_dir: "/var/lib/vxdb/snapshots"
   join: []  # List of existing nodes to join
   bootstrap_expect: 3  # Expected number of nodes in cluster
   retry_join:
@@ -149,7 +149,7 @@ engine:
     mutex_profile: false
     trace_profile: false
     profile_duration: 30s
-    profile_path: "/var/log/vexdb/profile"
+    profile_path: "/var/log/vxdb/profile"
 
 # API configuration
 api:
@@ -166,9 +166,9 @@ api:
     request_size_limit: 10485760  # 10MB
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexsearch.crt"
-      key_file: "/etc/vexdb/certs/vexsearch.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxsearch.crt"
+      key_file: "/etc/vxdb/certs/vxsearch.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -196,9 +196,9 @@ api:
     connection_timeout: 30s
     tls:
       enabled: true
-      cert_file: "/etc/vexdb/certs/vexsearch.crt"
-      key_file: "/etc/vexdb/certs/vexsearch.key"
-      ca_file: "/etc/vexdb/certs/ca.crt"
+      cert_file: "/etc/vxdb/certs/vxsearch.crt"
+      key_file: "/etc/vxdb/certs/vxsearch.key"
+      ca_file: "/etc/vxdb/certs/ca.crt"
       client_auth: false
       min_version: "1.2"
       max_version: "1.3"
@@ -240,8 +240,8 @@ auth:
     secret: ""  # JWT secret key
     algorithm: "HS256"
     expiration: 24h
-    issuer: "vexdb"
-    audience: "vexdb-clients"
+    issuer: "vxdb"
+    audience: "vxdb-clients"
   rate_limit:
     enabled: true
     requests_per_second: 1000
@@ -360,9 +360,9 @@ security:
   enabled: true
   tls:
     enabled: true
-    cert_file: "/etc/vexdb/certs/vexsearch.crt"
-    key_file: "/etc/vexdb/certs/vexsearch.key"
-    ca_file: "/etc/vexdb/certs/ca.crt"
+    cert_file: "/etc/vxdb/certs/vxsearch.crt"
+    key_file: "/etc/vxdb/certs/vxsearch.key"
+    ca_file: "/etc/vxdb/certs/ca.crt"
     client_auth: false
     min_version: "1.2"
     max_version: "1.3"
@@ -371,10 +371,10 @@ security:
   encryption:
     enabled: false
     algorithm: "aes-256-gcm"
-    key_file: "/etc/vexdb/encryption.key"
+    key_file: "/etc/vxdb/encryption.key"
   audit:
     enabled: true
-    log_file: "/var/log/vexdb/audit.log"
+    log_file: "/var/log/vxdb/audit.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days
@@ -483,4 +483,4 @@ performance_monitoring:
     mutex_profile: false
     trace_profile: false
     profile_duration: 30s
-    profile_path: "/var/log/vexdb/profile"
+    profile_path: "/var/log/vxdb/profile"

--- a/configs/vxstorage-production.yaml
+++ b/configs/vxstorage-production.yaml
@@ -1,4 +1,4 @@
-# VexDB Storage Service Production Configuration
+# VxDB Storage Service Production Configuration
 # This configuration is optimized for production environments
 
 # Server configuration
@@ -17,7 +17,7 @@ logging:
   format: "json"  # json, console
   output: "stdout"  # stdout, stderr, or file path
   file:
-    path: "/var/log/vexdb/vexstorage.log"
+    path: "/var/log/vxdb/vxstorage.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days
@@ -39,7 +39,7 @@ metrics:
   host: "0.0.0.0"
   port: 9094
   path: "/metrics"
-  namespace: "vexdb"
+  namespace: "vxdb"
   subsystem: "storage"
   buckets: [0.0001, 0.001, 0.01, 0.1, 1.0, 10.0]
   enable_profiling: false
@@ -48,7 +48,7 @@ metrics:
 # Tracing configuration
 tracing:
   enabled: true
-  service_name: "vexstorage"
+  service_name: "vxstorage"
   endpoint: "http://jaeger:14268/api/traces"
   sampling_rate: 0.1  # 10% sampling in production
   batch_size: 512
@@ -85,11 +85,11 @@ dashboard:
 
 # Cluster configuration
 cluster:
-  name: "vexdb-cluster"
+  name: "vxdb-cluster"
   node_id: ""  # Auto-generated if empty
-  data_dir: "/var/lib/vexdb/data"
-  wal_dir: "/var/lib/vexdb/wal"
-  snapshot_dir: "/var/lib/vexdb/snapshots"
+  data_dir: "/var/lib/vxdb/data"
+  wal_dir: "/var/lib/vxdb/wal"
+  snapshot_dir: "/var/lib/vxdb/snapshots"
   join: []  # List of existing nodes to join
   bootstrap_expect: 3  # Expected number of nodes in cluster
   retry_join:
@@ -110,9 +110,9 @@ cluster:
 # Storage configuration
 storage:
   # Data directory configuration
-  data_dir: "/var/lib/vexdb/storage"
-  wal_dir: "/var/lib/vexdb/wal"
-  temp_dir: "/var/lib/vexdb/temp"
+  data_dir: "/var/lib/vxdb/storage"
+  wal_dir: "/var/lib/vxdb/wal"
+  temp_dir: "/var/lib/vxdb/temp"
   
   # Segment configuration
   segment:
@@ -171,7 +171,7 @@ storage:
   # Manifest configuration
   manifest:
     enabled: true
-    path: "/var/lib/vexdb/manifest"
+    path: "/var/lib/vxdb/manifest"
     sync_interval: 5s
     backup_interval: 3600s  # 1 hour
     max_backups: 24  # Keep 24 hours of backups
@@ -183,7 +183,7 @@ storage:
   # WAL configuration
   wal:
     enabled: true
-    path: "/var/lib/vexdb/wal"
+    path: "/var/lib/vxdb/wal"
     max_file_size: 104857600  # 100MB
     max_files: 10
     sync_interval: 1s
@@ -246,7 +246,7 @@ engine:
     mutex_profile: false
     trace_profile: false
     profile_duration: 30s
-    profile_path: "/var/log/vexdb/profile"
+    profile_path: "/var/log/vxdb/profile"
 
 # Replication configuration
 replication:
@@ -282,9 +282,9 @@ grpc:
   connection_timeout: 30s
   tls:
     enabled: true
-    cert_file: "/etc/vexdb/certs/vexstorage.crt"
-    key_file: "/etc/vexdb/certs/vexstorage.key"
-    ca_file: "/etc/vexdb/certs/ca.crt"
+    cert_file: "/etc/vxdb/certs/vxstorage.crt"
+    key_file: "/etc/vxdb/certs/vxstorage.key"
+    ca_file: "/etc/vxdb/certs/ca.crt"
     client_auth: false
     min_version: "1.2"
     max_version: "1.3"
@@ -315,8 +315,8 @@ auth:
     secret: ""  # JWT secret key
     algorithm: "HS256"
     expiration: 24h
-    issuer: "vexdb"
-    audience: "vexdb-clients"
+    issuer: "vxdb"
+    audience: "vxdb-clients"
   rate_limit:
     enabled: true
     requests_per_second: 10000
@@ -346,7 +346,7 @@ health:
       type: "disk"
       enabled: true
       timeout: 5s
-      path: "/var/lib/vexdb"
+      path: "/var/lib/vxdb"
       threshold: 0.9  # 90% disk usage threshold
     - name: "cluster"
       type: "cluster"
@@ -376,9 +376,9 @@ security:
   enabled: true
   tls:
     enabled: true
-    cert_file: "/etc/vexdb/certs/vexstorage.crt"
-    key_file: "/etc/vexdb/certs/vexstorage.key"
-    ca_file: "/etc/vexdb/certs/ca.crt"
+    cert_file: "/etc/vxdb/certs/vxstorage.crt"
+    key_file: "/etc/vxdb/certs/vxstorage.key"
+    ca_file: "/etc/vxdb/certs/ca.crt"
     client_auth: false
     min_version: "1.2"
     max_version: "1.3"
@@ -387,10 +387,10 @@ security:
   encryption:
     enabled: false
     algorithm: "aes-256-gcm"
-    key_file: "/etc/vexdb/encryption.key"
+    key_file: "/etc/vxdb/encryption.key"
   audit:
     enabled: true
-    log_file: "/var/log/vexdb/audit.log"
+    log_file: "/var/log/vxdb/audit.log"
     max_size: 100  # MB
     max_backups: 10
     max_age: 30  # days
@@ -414,10 +414,10 @@ backup:
   encryption:
     enabled: false
     algorithm: "aes-256-gcm"
-    key_file: "/etc/vexdb/backup.key"
+    key_file: "/etc/vxdb/backup.key"
   destination:
     type: "local"  # local, s3, gcs, azure
-    path: "/var/lib/vexdb/backups"
+    path: "/var/lib/vxdb/backups"
     s3:
       bucket: ""
       region: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.8'
 
 services:
-  # VexDB Insert Service
-  vexinsert:
+  # VxDB Insert Service
+  vxinsert:
     build:
       context: .
-      dockerfile: cmd/vexinsert/Dockerfile
-    container_name: vexinsert
+      dockerfile: cmd/vxinsert/Dockerfile
+    container_name: vxinsert
     restart: unless-stopped
     ports:
       - "8080:8080"    # HTTP API
@@ -18,20 +18,20 @@ services:
       - "7946:7946"    # Gossip
       - "7947:7947"    # Serf
     volumes:
-      - vexinsert_data:/var/lib/vexdb/data
-      - vexinsert_wal:/var/lib/vexdb/wal
-      - vexinsert_snapshots:/var/lib/vexdb/snapshots
-      - vexinsert_buffer:/var/lib/vexdb/buffer
-      - vexinsert_logs:/var/log/vexdb
-      - ./configs/vexinsert-production.yaml:/etc/vexdb/config.yaml
-      - ./certs:/etc/vexdb/certs
+      - vxinsert_data:/var/lib/vxdb/data
+      - vxinsert_wal:/var/lib/vxdb/wal
+      - vxinsert_snapshots:/var/lib/vxdb/snapshots
+      - vxinsert_buffer:/var/lib/vxdb/buffer
+      - vxinsert_logs:/var/log/vxdb
+      - ./configs/vxinsert-production.yaml:/etc/vxdb/config.yaml
+      - ./certs:/etc/vxdb/certs
     environment:
-      - VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+      - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
     networks:
-      - vexdb_network
+      - vxdb_network
     depends_on:
-      - vexstorage
+      - vxstorage
     healthcheck:
       test: ["CMD", "/usr/local/bin/health-check.sh"]
       interval: 30s
@@ -39,12 +39,12 @@ services:
       retries: 3
       start_period: 5s
 
-  # VexDB Storage Service
-  vexstorage:
+  # VxDB Storage Service
+  vxstorage:
     build:
       context: .
-      dockerfile: cmd/vexstorage/Dockerfile
-    container_name: vexstorage
+      dockerfile: cmd/vxstorage/Dockerfile
+    container_name: vxstorage
     restart: unless-stopped
     ports:
       - "8082:8082"    # HTTP API
@@ -54,21 +54,21 @@ services:
       - "7948:7948"    # Gossip
       - "7949:7949"    # Serf
     volumes:
-      - vexstorage_data:/var/lib/vexdb/data
-      - vexstorage_wal:/var/lib/vexdb/wal
-      - vexstorage_snapshots:/var/lib/vexdb/snapshots
-      - vexstorage_storage:/var/lib/vexdb/storage
-      - vexstorage_temp:/var/lib/vexdb/temp
-      - vexstorage_manifest:/var/lib/vexdb/manifest
-      - vexstorage_backups:/var/lib/vexdb/backups
-      - vexstorage_logs:/var/log/vexdb
-      - ./configs/vexstorage-production.yaml:/etc/vexdb/config.yaml
-      - ./certs:/etc/vexdb/certs
+      - vxstorage_data:/var/lib/vxdb/data
+      - vxstorage_wal:/var/lib/vxdb/wal
+      - vxstorage_snapshots:/var/lib/vxdb/snapshots
+      - vxstorage_storage:/var/lib/vxdb/storage
+      - vxstorage_temp:/var/lib/vxdb/temp
+      - vxstorage_manifest:/var/lib/vxdb/manifest
+      - vxstorage_backups:/var/lib/vxdb/backups
+      - vxstorage_logs:/var/log/vxdb
+      - ./configs/vxstorage-production.yaml:/etc/vxdb/config.yaml
+      - ./certs:/etc/vxdb/certs
     environment:
-      - VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+      - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
     networks:
-      - vexdb_network
+      - vxdb_network
     healthcheck:
       test: ["CMD", "/usr/local/bin/health-check.sh"]
       interval: 30s
@@ -76,12 +76,12 @@ services:
       retries: 3
       start_period: 5s
 
-  # VexDB Search Service
-  vexsearch:
+  # VxDB Search Service
+  vxsearch:
     build:
       context: .
-      dockerfile: cmd/vexsearch/Dockerfile
-    container_name: vexsearch
+      dockerfile: cmd/vxsearch/Dockerfile
+    container_name: vxsearch
     restart: unless-stopped
     ports:
       - "8083:8083"    # HTTP API
@@ -91,20 +91,20 @@ services:
       - "7950:7950"    # Gossip
       - "7951:7951"    # Serf
     volumes:
-      - vexsearch_data:/var/lib/vexdb/data
-      - vexsearch_wal:/var/lib/vexdb/wal
-      - vexsearch_snapshots:/var/lib/vexdb/snapshots
-      - vexsearch_cache:/var/lib/vexdb/cache
-      - vexsearch_logs:/var/log/vexdb
-      - ./configs/vexsearch-production.yaml:/etc/vexdb/config.yaml
-      - ./certs:/etc/vexdb/certs
+      - vxsearch_data:/var/lib/vxdb/data
+      - vxsearch_wal:/var/lib/vxdb/wal
+      - vxsearch_snapshots:/var/lib/vxdb/snapshots
+      - vxsearch_cache:/var/lib/vxdb/cache
+      - vxsearch_logs:/var/log/vxdb
+      - ./configs/vxsearch-production.yaml:/etc/vxdb/config.yaml
+      - ./certs:/etc/vxdb/certs
     environment:
-      - VEXDB_CONFIG_FILE=/etc/vexdb/config.yaml
+      - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
     networks:
-      - vexdb_network
+      - vxdb_network
     depends_on:
-      - vexstorage
+      - vxstorage
     healthcheck:
       test: ["CMD", "/usr/local/bin/health-check.sh"]
       interval: 30s
@@ -130,7 +130,7 @@ services:
       - '--storage.tsdb.retention.time=200h'
       - '--web.enable-lifecycle'
     networks:
-      - vexdb_network
+      - vxdb_network
 
   # Grafana for visualization
   grafana:
@@ -147,7 +147,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
     networks:
-      - vexdb_network
+      - vxdb_network
     depends_on:
       - prometheus
 
@@ -163,7 +163,7 @@ services:
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     networks:
-      - vexdb_network
+      - vxdb_network
 
   # Redis for caching (optional)
   redis:
@@ -176,7 +176,7 @@ services:
       - redis_data:/data
     command: redis-server --appendonly yes
     networks:
-      - vexdb_network
+      - vxdb_network
 
   # Nginx reverse proxy (optional)
   nginx:
@@ -191,53 +191,53 @@ services:
       - ./configs/nginx/conf.d:/etc/nginx/conf.d
       - ./certs:/etc/nginx/certs
     networks:
-      - vexdb_network
+      - vxdb_network
     depends_on:
-      - vexinsert
-      - vexstorage
-      - vexsearch
+      - vxinsert
+      - vxstorage
+      - vxsearch
 
 volumes:
-  # VexDB Insert Service volumes
-  vexinsert_data:
+  # VxDB Insert Service volumes
+  vxinsert_data:
     driver: local
-  vexinsert_wal:
+  vxinsert_wal:
     driver: local
-  vexinsert_snapshots:
+  vxinsert_snapshots:
     driver: local
-  vexinsert_buffer:
+  vxinsert_buffer:
     driver: local
-  vexinsert_logs:
-    driver: local
-
-  # VexDB Storage Service volumes
-  vexstorage_data:
-    driver: local
-  vexstorage_wal:
-    driver: local
-  vexstorage_snapshots:
-    driver: local
-  vexstorage_storage:
-    driver: local
-  vexstorage_temp:
-    driver: local
-  vexstorage_manifest:
-    driver: local
-  vexstorage_backups:
-    driver: local
-  vexstorage_logs:
+  vxinsert_logs:
     driver: local
 
-  # VexDB Search Service volumes
-  vexsearch_data:
+  # VxDB Storage Service volumes
+  vxstorage_data:
     driver: local
-  vexsearch_wal:
+  vxstorage_wal:
     driver: local
-  vexsearch_snapshots:
+  vxstorage_snapshots:
     driver: local
-  vexsearch_cache:
+  vxstorage_storage:
     driver: local
-  vexsearch_logs:
+  vxstorage_temp:
+    driver: local
+  vxstorage_manifest:
+    driver: local
+  vxstorage_backups:
+    driver: local
+  vxstorage_logs:
+    driver: local
+
+  # VxDB Search Service volumes
+  vxsearch_data:
+    driver: local
+  vxsearch_wal:
+    driver: local
+  vxsearch_snapshots:
+    driver: local
+  vxsearch_cache:
+    driver: local
+  vxsearch_logs:
     driver: local
 
   # Monitoring volumes
@@ -249,7 +249,7 @@ volumes:
     driver: local
 
 networks:
-  vexdb_network:
+  vxdb_network:
     driver: bridge
     ipam:
       config:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vexdb
+module vxdb
 
 go 1.23.0
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,21 +28,21 @@ func LoadConfig(serviceType, path string) (Config, error) {
 	}
 }
 
-// InsertConfig holds configuration for the vexinsert service
+// InsertConfig holds configuration for the vxinsert service
 type InsertConfig struct {
-	Server   ServerConfig   `yaml:"server"`
-	Cluster  ClusterConfig  `yaml:"cluster"`
+	Server    ServerConfig   `yaml:"server"`
+	Cluster   ClusterConfig  `yaml:"cluster"`
 	Protocols ProtocolConfig `yaml:"protocols"`
 }
 
-// StorageConfig holds configuration for the vexstorage service
+// StorageConfig holds configuration for the vxstorage service
 type StorageConfig struct {
-	Server   ServerConfig    `yaml:"server"`
-	Storage  StorageEngineConfig `yaml:"storage"`
-	Cluster  ClusterConfig   `yaml:"cluster"`
+	Server  ServerConfig        `yaml:"server"`
+	Storage StorageEngineConfig `yaml:"storage"`
+	Cluster ClusterConfig       `yaml:"cluster"`
 }
 
-// SearchConfig holds configuration for the vexsearch service
+// SearchConfig holds configuration for the vxsearch service
 type SearchConfig struct {
 	Server  ServerConfig  `yaml:"server"`
 	Cluster ClusterConfig `yaml:"cluster"`
@@ -61,42 +61,42 @@ type ClusterConfig struct {
 	NodeID       string   `yaml:"node_id"`
 	ClusterNodes []string `yaml:"cluster_nodes"`
 	Replication  struct {
-		Enabled      bool   `yaml:"enabled"`
-		Factor       int    `yaml:"factor"`
-		Strategy     string `yaml:"strategy"`
+		Enabled  bool   `yaml:"enabled"`
+		Factor   int    `yaml:"factor"`
+		Strategy string `yaml:"strategy"`
 	} `yaml:"replication"`
 }
 
 // ProtocolConfig holds protocol adapter configuration
 type ProtocolConfig struct {
 	HTTP struct {
-		Enabled bool   `yaml:"enabled"`
-		Port    int    `yaml:"port"`
+		Enabled bool `yaml:"enabled"`
+		Port    int  `yaml:"port"`
 	} `yaml:"http"`
 	WebSocket struct {
-		Enabled bool   `yaml:"enabled"`
-		Port    int    `yaml:"port"`
+		Enabled bool `yaml:"enabled"`
+		Port    int  `yaml:"port"`
 	} `yaml:"websocket"`
 	GRPC struct {
-		Enabled bool   `yaml:"enabled"`
-		Port    int    `yaml:"port"`
+		Enabled bool `yaml:"enabled"`
+		Port    int  `yaml:"port"`
 	} `yaml:"grpc"`
 	Redis struct {
-		Enabled bool   `yaml:"enabled"`
-		Port    int    `yaml:"port"`
+		Enabled bool `yaml:"enabled"`
+		Port    int  `yaml:"port"`
 	} `yaml:"redis"`
 }
 
 // StorageEngineConfig holds storage engine configuration
 type StorageEngineConfig struct {
-	DataDir           string `yaml:"data_dir"`
-	SegmentSize       int    `yaml:"segment_size"`
-	BufferSize        int    `yaml:"buffer_size"`
-	FlushInterval     int    `yaml:"flush_interval"`
-	Compression       string `yaml:"compression"`
+	DataDir       string `yaml:"data_dir"`
+	SegmentSize   int    `yaml:"segment_size"`
+	BufferSize    int    `yaml:"buffer_size"`
+	FlushInterval int    `yaml:"flush_interval"`
+	Compression   string `yaml:"compression"`
 }
 
-// LoadInsertConfig loads configuration for vexinsert service
+// LoadInsertConfig loads configuration for vxinsert service
 func LoadInsertConfig(path string) (*InsertConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -111,7 +111,7 @@ func LoadInsertConfig(path string) (*InsertConfig, error) {
 	return &config, nil
 }
 
-// LoadStorageConfig loads configuration for vexstorage service
+// LoadStorageConfig loads configuration for vxstorage service
 func LoadStorageConfig(path string) (*StorageConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -126,7 +126,7 @@ func LoadStorageConfig(path string) (*StorageConfig, error) {
 	return &config, nil
 }
 
-// LoadSearchConfig loads configuration for vexsearch service
+// LoadSearchConfig loads configuration for vxsearch service
 func LoadSearchConfig(path string) (*SearchConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	cfg "vexdb/internal/config"
+	cfg "vxdb/internal/config"
 )
 
 func TestLoadConfigUnknownService(t *testing.T) {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"vexdb/internal/errors"
+	"vxdb/internal/errors"
 )
 
 // Validator defines the interface for configuration validation

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	cfg "vexdb/internal/config"
+	cfg "vxdb/internal/config"
 )
 
 type simple struct {
@@ -14,13 +14,13 @@ type simple struct {
 func TestConfigValidator(t *testing.T) {
 	v := cfg.NewConfigValidator()
 	v.AddSchema("port", &cfg.Schema{Type: "int", Required: true, Rules: []cfg.ValidationRule{cfg.Port()}})
-	v.AddSchema("name", &cfg.Schema{Type: "string", Default: "vex"})
+	v.AddSchema("name", &cfg.Schema{Type: "string", Default: "vx"})
 
 	s := &simple{Port: 8080}
 	if err := v.Validate(s); err != nil {
 		t.Fatalf("validate: %v", err)
 	}
-	if s.Name != "vex" {
+	if s.Name != "vx" {
 		t.Fatalf("expected default name applied, got %s", s.Name)
 	}
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -6,178 +6,178 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"vexdb/internal/errors"
+	"vxdb/internal/errors"
 )
 
-// Context keys for VexDB context values
+// Context keys for VxDB context values
 type contextKey string
 
 const (
 	// RequestIDKey is the key for the request ID in the context
 	RequestIDKey contextKey = "request_id"
-	
+
 	// TraceIDKey is the key for the trace ID in the context
 	TraceIDKey contextKey = "trace_id"
-	
+
 	// SpanIDKey is the key for the span ID in the context
 	SpanIDKey contextKey = "span_id"
-	
+
 	// UserIDKey is the key for the user ID in the context
 	UserIDKey contextKey = "user_id"
-	
+
 	// ServiceNameKey is the key for the service name in the context
 	ServiceNameKey contextKey = "service_name"
-	
+
 	// OperationNameKey is the key for the operation name in the context
 	OperationNameKey contextKey = "operation_name"
-	
+
 	// StartTimeKey is the key for the start time in the context
 	StartTimeKey contextKey = "start_time"
-	
+
 	// TimeoutKey is the key for the timeout in the context
 	TimeoutKey contextKey = "timeout"
-	
+
 	// MetadataKey is the key for metadata in the context
 	MetadataKey contextKey = "metadata"
-	
+
 	// ClusterIDKey is the key for the cluster ID in the context
 	ClusterIDKey contextKey = "cluster_id"
-	
+
 	// NodeIDKey is the key for the node ID in the context
 	NodeIDKey contextKey = "node_id"
-	
+
 	// VectorIDKey is the key for the vector ID in the context
 	VectorIDKey contextKey = "vector_id"
-	
+
 	// QueryIDKey is the key for the query ID in the context
 	QueryIDKey contextKey = "query_id"
-	
+
 	// BatchIDKey is the key for the batch ID in the context
 	BatchIDKey contextKey = "batch_id"
-	
+
 	// ReplicationFactorKey is the key for the replication factor in the context
 	ReplicationFactorKey contextKey = "replication_factor"
-	
+
 	// ConsistencyLevelKey is the key for the consistency level in the context
 	ConsistencyLevelKey contextKey = "consistency_level"
-	
+
 	// RetryCountKey is the key for the retry count in the context
 	RetryCountKey contextKey = "retry_count"
-	
+
 	// DeadlineKey is the key for the deadline in the context
 	DeadlineKey contextKey = "deadline"
 )
 
-// Context represents a VexDB context with additional metadata
+// Context represents a VxDB context with additional metadata
 type Context struct {
-	RequestID        string
-	TraceID          string
-	SpanID           string
-	UserID           string
-	ServiceName      string
-	OperationName    string
-	StartTime        time.Time
-	Timeout          time.Duration
-	Metadata         map[string]interface{}
-	ClusterID        string
-	NodeID           string
-	VectorID         string
-	QueryID          string
-	BatchID          string
+	RequestID         string
+	TraceID           string
+	SpanID            string
+	UserID            string
+	ServiceName       string
+	OperationName     string
+	StartTime         time.Time
+	Timeout           time.Duration
+	Metadata          map[string]interface{}
+	ClusterID         string
+	NodeID            string
+	VectorID          string
+	QueryID           string
+	BatchID           string
 	ReplicationFactor int
-	ConsistencyLevel string
-	RetryCount       int
-	Deadline         time.Time
+	ConsistencyLevel  string
+	RetryCount        int
+	Deadline          time.Time
 }
 
-// NewContext creates a new VexDB context
+// NewContext creates a new VxDB context
 func NewContext(ctx context.Context) *Context {
-	vexCtx := &Context{
+	vxCtx := &Context{
 		StartTime: time.Now(),
 		Metadata:  make(map[string]interface{}),
 	}
-	
+
 	// Extract existing values from context if they exist
 	if requestID := ctx.Value(RequestIDKey); requestID != nil {
-		vexCtx.RequestID = requestID.(string)
+		vxCtx.RequestID = requestID.(string)
 	} else {
-		vexCtx.RequestID = generateID()
+		vxCtx.RequestID = generateID()
 	}
-	
+
 	if traceID := ctx.Value(TraceIDKey); traceID != nil {
-		vexCtx.TraceID = traceID.(string)
+		vxCtx.TraceID = traceID.(string)
 	} else {
-		vexCtx.TraceID = generateID()
+		vxCtx.TraceID = generateID()
 	}
-	
+
 	if spanID := ctx.Value(SpanIDKey); spanID != nil {
-		vexCtx.SpanID = spanID.(string)
+		vxCtx.SpanID = spanID.(string)
 	} else {
-		vexCtx.SpanID = generateID()
+		vxCtx.SpanID = generateID()
 	}
-	
+
 	if userID := ctx.Value(UserIDKey); userID != nil {
-		vexCtx.UserID = userID.(string)
+		vxCtx.UserID = userID.(string)
 	}
-	
+
 	if serviceName := ctx.Value(ServiceNameKey); serviceName != nil {
-		vexCtx.ServiceName = serviceName.(string)
+		vxCtx.ServiceName = serviceName.(string)
 	}
-	
+
 	if operationName := ctx.Value(OperationNameKey); operationName != nil {
-		vexCtx.OperationName = operationName.(string)
+		vxCtx.OperationName = operationName.(string)
 	}
-	
+
 	if timeout := ctx.Value(TimeoutKey); timeout != nil {
-		vexCtx.Timeout = timeout.(time.Duration)
+		vxCtx.Timeout = timeout.(time.Duration)
 	}
-	
+
 	if metadata := ctx.Value(MetadataKey); metadata != nil {
 		if metaMap, ok := metadata.(map[string]interface{}); ok {
-			vexCtx.Metadata = metaMap
+			vxCtx.Metadata = metaMap
 		}
 	}
-	
+
 	if clusterID := ctx.Value(ClusterIDKey); clusterID != nil {
-		vexCtx.ClusterID = clusterID.(string)
+		vxCtx.ClusterID = clusterID.(string)
 	}
-	
+
 	if nodeID := ctx.Value(NodeIDKey); nodeID != nil {
-		vexCtx.NodeID = nodeID.(string)
+		vxCtx.NodeID = nodeID.(string)
 	}
-	
+
 	if vectorID := ctx.Value(VectorIDKey); vectorID != nil {
-		vexCtx.VectorID = vectorID.(string)
+		vxCtx.VectorID = vectorID.(string)
 	}
-	
+
 	if queryID := ctx.Value(QueryIDKey); queryID != nil {
-		vexCtx.QueryID = queryID.(string)
+		vxCtx.QueryID = queryID.(string)
 	}
-	
+
 	if batchID := ctx.Value(BatchIDKey); batchID != nil {
-		vexCtx.BatchID = batchID.(string)
+		vxCtx.BatchID = batchID.(string)
 	}
-	
+
 	if replicationFactor := ctx.Value(ReplicationFactorKey); replicationFactor != nil {
-		vexCtx.ReplicationFactor = replicationFactor.(int)
+		vxCtx.ReplicationFactor = replicationFactor.(int)
 	}
-	
+
 	if consistencyLevel := ctx.Value(ConsistencyLevelKey); consistencyLevel != nil {
-		vexCtx.ConsistencyLevel = consistencyLevel.(string)
+		vxCtx.ConsistencyLevel = consistencyLevel.(string)
 	}
-	
+
 	if retryCount := ctx.Value(RetryCountKey); retryCount != nil {
-		vexCtx.RetryCount = retryCount.(int)
+		vxCtx.RetryCount = retryCount.(int)
 	}
-	
+
 	if deadline, ok := ctx.Deadline(); ok {
-		vexCtx.Deadline = deadline
+		vxCtx.Deadline = deadline
 	}
-	
-	return vexCtx
+
+	return vxCtx
 }
 
-// ToContext converts the VexDB context to a standard context
+// ToContext converts the VxDB context to a standard context
 func (c *Context) ToContext(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, RequestIDKey, c.RequestID)
 	ctx = context.WithValue(ctx, TraceIDKey, c.TraceID)
@@ -197,7 +197,7 @@ func (c *Context) ToContext(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, ConsistencyLevelKey, c.ConsistencyLevel)
 	ctx = context.WithValue(ctx, RetryCountKey, c.RetryCount)
 	ctx = context.WithValue(ctx, DeadlineKey, c.Deadline)
-	
+
 	return ctx
 }
 
@@ -368,32 +368,32 @@ func (c *Context) Validate() error {
 // Copy creates a copy of the context
 func (c *Context) Copy() *Context {
 	copy := &Context{
-		RequestID:        c.RequestID,
-		TraceID:          c.TraceID,
-		SpanID:           c.SpanID,
-		UserID:           c.UserID,
-		ServiceName:      c.ServiceName,
-		OperationName:    c.OperationName,
-		StartTime:        c.StartTime,
-		Timeout:          c.Timeout,
-		ClusterID:        c.ClusterID,
-		NodeID:           c.NodeID,
-		VectorID:         c.VectorID,
-		QueryID:          c.QueryID,
-		BatchID:          c.BatchID,
+		RequestID:         c.RequestID,
+		TraceID:           c.TraceID,
+		SpanID:            c.SpanID,
+		UserID:            c.UserID,
+		ServiceName:       c.ServiceName,
+		OperationName:     c.OperationName,
+		StartTime:         c.StartTime,
+		Timeout:           c.Timeout,
+		ClusterID:         c.ClusterID,
+		NodeID:            c.NodeID,
+		VectorID:          c.VectorID,
+		QueryID:           c.QueryID,
+		BatchID:           c.BatchID,
 		ReplicationFactor: c.ReplicationFactor,
-		ConsistencyLevel: c.ConsistencyLevel,
-		RetryCount:       c.RetryCount,
-		Deadline:         c.Deadline,
+		ConsistencyLevel:  c.ConsistencyLevel,
+		RetryCount:        c.RetryCount,
+		Deadline:          c.Deadline,
 	}
-	
+
 	if c.Metadata != nil {
 		copy.Metadata = make(map[string]interface{})
 		for k, v := range c.Metadata {
 			copy.Metadata[k] = v
 		}
 	}
-	
+
 	return copy
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-// VexError represents a custom error type for VexDB
-type VexError struct {
+// VxError represents a custom error type for VxDB
+type VxError struct {
 	Code      ErrorCode
 	Message   string
 	Details   map[string]interface{}
@@ -35,28 +35,28 @@ const (
 	ErrorCodeInternal
 	ErrorCodeUnavailable
 	ErrorCodeDeadlineExceeded
-	
+
 	// Vector-specific errors
 	ErrorCodeInvalidVector
 	ErrorCodeVectorNotFound
 	ErrorCodeVectorDimensionMismatch
 	ErrorCodeVectorTooLarge
 	ErrorCodeVectorCorrupted
-	
+
 	// Cluster-specific errors
 	ErrorCodeClusterNotFound
 	ErrorCodeClusterNotReady
 	ErrorCodeClusterFull
 	ErrorCodeClusterInconsistent
 	ErrorCodeClusterRebalanceFailed
-	
+
 	// Node-specific errors
 	ErrorCodeNodeNotFound
 	ErrorCodeNodeUnhealthy
 	ErrorCodeNodeOverloaded
 	ErrorCodeNodeDisconnected
 	ErrorCodeNodeRecoveryFailed
-	
+
 	// Storage-specific errors
 	ErrorCodeStorageFull
 	ErrorCodeStorageCorrupted
@@ -64,7 +64,7 @@ const (
 	ErrorCodeStorageWriteFailed
 	ErrorCodeStorageReadFailed
 	ErrorCodeStorageCompactionFailed
-	
+
 	// Search-specific errors
 	ErrorCodeSearchFailed
 	ErrorCodeQueryInvalid
@@ -72,41 +72,41 @@ const (
 	ErrorCodeQueryCancelled
 	ErrorCodeSearchIndexCorrupted
 	ErrorCodeSearchNotAvailable
-	
+
 	// Network-specific errors
 	ErrorCodeNetworkUnavailable
 	ErrorCodeConnectionFailed
 	ErrorCodeConnectionTimeout
 	ErrorCodeConnectionRefused
 	ErrorCodeNetworkPartition
-	
+
 	// Configuration-specific errors
 	ErrorCodeConfigInvalid
 	ErrorCodeConfigNotFound
 	ErrorCodeConfigParseFailed
 	ErrorCodeConfigValidationFailed
 	ErrorCodeConfigUpdateFailed
-	
+
 	// Protocol-specific errors
 	ErrorCodeProtocolError
 	ErrorCodeProtocolNotSupported
 	ErrorCodeProtocolVersionMismatch
 	ErrorCodeProtocolMessageInvalid
 	ErrorCodeProtocolMessageTooLarge
-	
+
 	// Replication-specific errors
 	ErrorCodeReplicationFailed
 	ErrorCodeReplicationTimeout
 	ErrorCodeReplicationInconsistent
 	ErrorCodeReplicationQuorumNotReached
 	ErrorCodeReplicationConflict
-	
+
 	// Metrics-specific errors
 	ErrorCodeMetricsCollectionFailed
 	ErrorCodeMetricsExportFailed
 	ErrorCodeMetricsInvalid
 	ErrorCodeMetricsTimeout
-	
+
 	// Health-specific errors
 	ErrorCodeHealthCheckFailed
 	ErrorCodeHealthCheckTimeout
@@ -115,7 +115,7 @@ const (
 )
 
 // Error returns the error message
-func (e *VexError) Error() string {
+func (e *VxError) Error() string {
 	if e.Cause != nil {
 		return fmt.Sprintf("%s: %s (caused by: %v)", e.Code.String(), e.Message, e.Cause)
 	}
@@ -123,13 +123,13 @@ func (e *VexError) Error() string {
 }
 
 // Unwrap returns the underlying error
-func (e *VexError) Unwrap() error {
+func (e *VxError) Unwrap() error {
 	return e.Cause
 }
 
 // Is checks if the error matches the target error
-func (e *VexError) Is(target error) bool {
-	var other *VexError
+func (e *VxError) Is(target error) bool {
+	var other *VxError
 	if errors.As(target, &other) {
 		return e.Code == other.Code
 	}
@@ -282,9 +282,9 @@ func (c ErrorCode) String() string {
 	}
 }
 
-// New creates a new VexError
-func New(code ErrorCode, message string) *VexError {
-	return &VexError{
+// New creates a new VxError
+func New(code ErrorCode, message string) *VxError {
+	return &VxError{
 		Code:      code,
 		Message:   message,
 		Details:   make(map[string]interface{}),
@@ -293,8 +293,8 @@ func New(code ErrorCode, message string) *VexError {
 }
 
 // Wrap wraps an existing error with additional context
-func Wrap(err error, code ErrorCode, message string) *VexError {
-	return &VexError{
+func Wrap(err error, code ErrorCode, message string) *VxError {
+	return &VxError{
 		Code:      code,
 		Message:   message,
 		Details:   make(map[string]interface{}),
@@ -304,7 +304,7 @@ func Wrap(err error, code ErrorCode, message string) *VexError {
 }
 
 // WithDetails adds details to the error
-func (e *VexError) WithDetails(details map[string]interface{}) *VexError {
+func (e *VxError) WithDetails(details map[string]interface{}) *VxError {
 	for k, v := range details {
 		e.Details[k] = v
 	}
@@ -312,37 +312,37 @@ func (e *VexError) WithDetails(details map[string]interface{}) *VexError {
 }
 
 // WithDetail adds a single detail to the error
-func (e *VexError) WithDetail(key string, value interface{}) *VexError {
+func (e *VxError) WithDetail(key string, value interface{}) *VxError {
 	e.Details[key] = value
 	return e
 }
 
 // WithStack adds stack trace information
-func (e *VexError) WithStack(stack string) *VexError {
+func (e *VxError) WithStack(stack string) *VxError {
 	e.Stack = stack
 	return e
 }
 
-// IsErrorCode checks if the error is a VexError with the specific error code
+// IsErrorCode checks if the error is a VxError with the specific error code
 func IsErrorCode(err error, code ErrorCode) bool {
-	var vexErr *VexError
-	return errors.As(err, &vexErr) && vexErr.Code == code
+	var vxErr *VxError
+	return errors.As(err, &vxErr) && vxErr.Code == code
 }
 
-// GetErrorCode returns the error code from a VexError
+// GetErrorCode returns the error code from a VxError
 func GetErrorCode(err error) ErrorCode {
-	var vexErr *VexError
-	if errors.As(err, &vexErr) {
-		return vexErr.Code
+	var vxErr *VxError
+	if errors.As(err, &vxErr) {
+		return vxErr.Code
 	}
 	return ErrorCodeUnknown
 }
 
-// GetErrorDetails returns the details from a VexError
+// GetErrorDetails returns the details from a VxError
 func GetErrorDetails(err error) map[string]interface{} {
-	var vexErr *VexError
-	if errors.As(err, &vexErr) {
-		return vexErr.Details
+	var vxErr *VxError
+	if errors.As(err, &vxErr) {
+		return vxErr.Details
 	}
 	return nil
 }
@@ -350,144 +350,144 @@ func GetErrorDetails(err error) map[string]interface{} {
 // Predefined error constructors
 
 // Vector errors
-func NewInvalidVectorError(message string) *VexError {
+func NewInvalidVectorError(message string) *VxError {
 	return New(ErrorCodeInvalidVector, message)
 }
 
-func NewVectorNotFoundError(vectorID string) *VexError {
+func NewVectorNotFoundError(vectorID string) *VxError {
 	return New(ErrorCodeVectorNotFound, fmt.Sprintf("vector not found: %s", vectorID)).
 		WithDetail("vector_id", vectorID)
 }
 
-func NewVectorDimensionMismatchError(expected, actual int) *VexError {
+func NewVectorDimensionMismatchError(expected, actual int) *VxError {
 	return New(ErrorCodeVectorDimensionMismatch, fmt.Sprintf("vector dimension mismatch: expected %d, got %d", expected, actual)).
 		WithDetail("expected_dimension", expected).
 		WithDetail("actual_dimension", actual)
 }
 
-func NewVectorTooLargeError(size int64, maxSize int64) *VexError {
+func NewVectorTooLargeError(size int64, maxSize int64) *VxError {
 	return New(ErrorCodeVectorTooLarge, fmt.Sprintf("vector too large: size %d exceeds max size %d", size, maxSize)).
 		WithDetail("size", size).
 		WithDetail("max_size", maxSize)
 }
 
 // Cluster errors
-func NewClusterNotFoundError(clusterID string) *VexError {
+func NewClusterNotFoundError(clusterID string) *VxError {
 	return New(ErrorCodeClusterNotFound, fmt.Sprintf("cluster not found: %s", clusterID)).
 		WithDetail("cluster_id", clusterID)
 }
 
-func NewClusterNotReadyError(clusterID string) *VexError {
+func NewClusterNotReadyError(clusterID string) *VxError {
 	return New(ErrorCodeClusterNotReady, fmt.Sprintf("cluster not ready: %s", clusterID)).
 		WithDetail("cluster_id", clusterID)
 }
 
-func NewClusterFullError(clusterID string) *VexError {
+func NewClusterFullError(clusterID string) *VxError {
 	return New(ErrorCodeClusterFull, fmt.Sprintf("cluster is full: %s", clusterID)).
 		WithDetail("cluster_id", clusterID)
 }
 
 // Node errors
-func NewNodeNotFoundError(nodeID string) *VexError {
+func NewNodeNotFoundError(nodeID string) *VxError {
 	return New(ErrorCodeNodeNotFound, fmt.Sprintf("node not found: %s", nodeID)).
 		WithDetail("node_id", nodeID)
 }
 
-func NewNodeUnhealthyError(nodeID string) *VexError {
+func NewNodeUnhealthyError(nodeID string) *VxError {
 	return New(ErrorCodeNodeUnhealthy, fmt.Sprintf("node is unhealthy: %s", nodeID)).
 		WithDetail("node_id", nodeID)
 }
 
-func NewNodeOverloadedError(nodeID string) *VexError {
+func NewNodeOverloadedError(nodeID string) *VxError {
 	return New(ErrorCodeNodeOverloaded, fmt.Sprintf("node is overloaded: %s", nodeID)).
 		WithDetail("node_id", nodeID)
 }
 
 // Storage errors
-func NewStorageFullError() *VexError {
+func NewStorageFullError() *VxError {
 	return New(ErrorCodeStorageFull, "storage is full")
 }
 
-func NewStorageCorruptedError(path string) *VexError {
+func NewStorageCorruptedError(path string) *VxError {
 	return New(ErrorCodeStorageCorrupted, fmt.Sprintf("storage corrupted: %s", path)).
 		WithDetail("path", path)
 }
 
-func NewStorageUnavailableError() *VexError {
+func NewStorageUnavailableError() *VxError {
 	return New(ErrorCodeStorageUnavailable, "storage is unavailable")
 }
 
 // Search errors
-func NewSearchFailedError(message string) *VexError {
+func NewSearchFailedError(message string) *VxError {
 	return New(ErrorCodeSearchFailed, message)
 }
 
-func NewQueryInvalidError(message string) *VexError {
+func NewQueryInvalidError(message string) *VxError {
 	return New(ErrorCodeQueryInvalid, message)
 }
 
-func NewQueryTimeoutError(queryID string) *VexError {
+func NewQueryTimeoutError(queryID string) *VxError {
 	return New(ErrorCodeQueryTimeout, fmt.Sprintf("query timeout: %s", queryID)).
 		WithDetail("query_id", queryID)
 }
 
 // Network errors
-func NewNetworkUnavailableError() *VexError {
+func NewNetworkUnavailableError() *VxError {
 	return New(ErrorCodeNetworkUnavailable, "network is unavailable")
 }
 
-func NewConnectionFailedError(address string) *VexError {
+func NewConnectionFailedError(address string) *VxError {
 	return New(ErrorCodeConnectionFailed, fmt.Sprintf("connection failed: %s", address)).
 		WithDetail("address", address)
 }
 
-func NewConnectionTimeoutError(address string) *VexError {
+func NewConnectionTimeoutError(address string) *VxError {
 	return New(ErrorCodeConnectionTimeout, fmt.Sprintf("connection timeout: %s", address)).
 		WithDetail("address", address)
 }
 
 // Configuration errors
-func NewConfigInvalidError(message string) *VexError {
+func NewConfigInvalidError(message string) *VxError {
 	return New(ErrorCodeConfigInvalid, message)
 }
 
-func NewConfigNotFoundError(path string) *VexError {
+func NewConfigNotFoundError(path string) *VxError {
 	return New(ErrorCodeConfigNotFound, fmt.Sprintf("config not found: %s", path)).
 		WithDetail("path", path)
 }
 
-func NewConfigParseFailedError(path string, err error) *VexError {
+func NewConfigParseFailedError(path string, err error) *VxError {
 	return Wrap(err, ErrorCodeConfigParseFailed, fmt.Sprintf("config parse failed: %s", path)).
 		WithDetail("path", path)
 }
 
 // Replication errors
-func NewReplicationFailedError(message string) *VexError {
+func NewReplicationFailedError(message string) *VxError {
 	return New(ErrorCodeReplicationFailed, message)
 }
 
-func NewReplicationTimeoutError() *VexError {
+func NewReplicationTimeoutError() *VxError {
 	return New(ErrorCodeReplicationTimeout, "replication timeout")
 }
 
-func NewReplicationQuorumNotReachedError(required, actual int) *VexError {
+func NewReplicationQuorumNotReachedError(required, actual int) *VxError {
 	return New(ErrorCodeReplicationQuorumNotReached, fmt.Sprintf("replication quorum not reached: required %d, got %d", required, actual)).
 		WithDetail("required", required).
 		WithDetail("actual", actual)
 }
 
 // Health check errors
-func NewHealthCheckFailedError(service string) *VexError {
+func NewHealthCheckFailedError(service string) *VxError {
 	return New(ErrorCodeHealthCheckFailed, fmt.Sprintf("health check failed: %s", service)).
 		WithDetail("service", service)
 }
 
-func NewHealthCheckTimeoutError(service string) *VexError {
+func NewHealthCheckTimeoutError(service string) *VxError {
 	return New(ErrorCodeHealthCheckTimeout, fmt.Sprintf("health check timeout: %s", service)).
 		WithDetail("service", service)
 }
 
 // NewInvalidArgumentError creates a new invalid argument error
-func NewInvalidArgumentError(message string) *VexError {
+func NewInvalidArgumentError(message string) *VxError {
 	return New(ErrorCodeInvalidArgument, message)
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -3,7 +3,7 @@ package errors_test
 import (
 	"errors"
 	"testing"
-	ve "vexdb/internal/errors"
+	ve "vxdb/internal/errors"
 )
 
 func TestErrorCreationAndFormatting(t *testing.T) {

--- a/internal/health/interfaces.go
+++ b/internal/health/interfaces.go
@@ -7,15 +7,15 @@ import (
 
 // HealthStatus represents the health status of a component
 type HealthStatus struct {
-	Status      HealthState    `json:"status"`
-	Message     string         `json:"message,omitempty"`
-	Details     map[string]interface{} `json:"details,omitempty"`
-	Timestamp   time.Time      `json:"timestamp"`
-	Component   string         `json:"component"`
-	Version     string         `json:"version,omitempty"`
-	Uptime      time.Duration  `json:"uptime,omitempty"`
-	Checks      []*HealthCheck `json:"checks,omitempty"`
-	Metrics     map[string]interface{} `json:"metrics,omitempty"`
+	Status    HealthState            `json:"status"`
+	Message   string                 `json:"message,omitempty"`
+	Details   map[string]interface{} `json:"details,omitempty"`
+	Timestamp time.Time              `json:"timestamp"`
+	Component string                 `json:"component"`
+	Version   string                 `json:"version,omitempty"`
+	Uptime    time.Duration          `json:"uptime,omitempty"`
+	Checks    []*HealthCheck         `json:"checks,omitempty"`
+	Metrics   map[string]interface{} `json:"metrics,omitempty"`
 }
 
 // HealthState represents the health state
@@ -30,27 +30,27 @@ const (
 
 // HealthCheck represents a single health check
 type HealthCheck struct {
-	Name        string                 `json:"name"`
-	Status      HealthState            `json:"status"`
-	Message     string                 `json:"message,omitempty"`
-	Details     map[string]interface{} `json:"details,omitempty"`
-	Duration    time.Duration          `json:"duration"`
-	Timestamp   time.Time              `json:"timestamp"`
-	Component   string                 `json:"component"`
-	Metrics     map[string]interface{} `json:"metrics,omitempty"`
+	Name      string                 `json:"name"`
+	Status    HealthState            `json:"status"`
+	Message   string                 `json:"message,omitempty"`
+	Details   map[string]interface{} `json:"details,omitempty"`
+	Duration  time.Duration          `json:"duration"`
+	Timestamp time.Time              `json:"timestamp"`
+	Component string                 `json:"component"`
+	Metrics   map[string]interface{} `json:"metrics,omitempty"`
 }
 
 // HealthChecker defines the interface for health checking
 type HealthChecker interface {
 	// CheckHealth performs a health check
 	CheckHealth(ctx context.Context, detailed bool) (*HealthStatus, error)
-	
+
 	// GetName returns the name of the health checker
 	GetName() string
-	
+
 	// GetComponent returns the component being checked
 	GetComponent() string
-	
+
 	// GetVersion returns the version of the component
 	GetVersion() string
 }
@@ -59,66 +59,66 @@ type HealthChecker interface {
 type HealthRegistry interface {
 	// Register registers a health checker
 	Register(checker HealthChecker) error
-	
+
 	// Unregister unregisters a health checker
 	Unregister(name string) error
-	
+
 	// GetChecker returns a health checker by name
 	GetChecker(name string) (HealthChecker, error)
-	
+
 	// ListCheckers returns all registered health checkers
 	ListCheckers() []HealthChecker
-	
+
 	// CheckAll checks the health of all registered components
 	CheckAll(ctx context.Context, detailed bool) (*SystemHealth, error)
-	
+
 	// CheckComponent checks the health of a specific component
 	CheckComponent(ctx context.Context, name string, detailed bool) (*HealthStatus, error)
 }
 
 // SystemHealth represents the overall system health
 type SystemHealth struct {
-	Status      HealthState              `json:"status"`
-	Message     string                   `json:"message,omitempty"`
-	Details     map[string]interface{}   `json:"details,omitempty"`
-	Timestamp   time.Time                `json:"timestamp"`
-	Version     string                   `json:"version,omitempty"`
-	Uptime      time.Duration            `json:"uptime,omitempty"`
-	Components  map[string]*HealthStatus `json:"components"`
-	Summary     *HealthSummary           `json:"summary,omitempty"`
-	Metrics     map[string]interface{}   `json:"metrics,omitempty"`
+	Status     HealthState              `json:"status"`
+	Message    string                   `json:"message,omitempty"`
+	Details    map[string]interface{}   `json:"details,omitempty"`
+	Timestamp  time.Time                `json:"timestamp"`
+	Version    string                   `json:"version,omitempty"`
+	Uptime     time.Duration            `json:"uptime,omitempty"`
+	Components map[string]*HealthStatus `json:"components"`
+	Summary    *HealthSummary           `json:"summary,omitempty"`
+	Metrics    map[string]interface{}   `json:"metrics,omitempty"`
 }
 
 // HealthSummary provides a summary of system health
 type HealthSummary struct {
-	TotalComponents    int          `json:"total_components"`
-	HealthyComponents  int          `json:"healthy_components"`
-	DegradedComponents int          `json:"degraded_components"`
+	TotalComponents     int         `json:"total_components"`
+	HealthyComponents   int         `json:"healthy_components"`
+	DegradedComponents  int         `json:"degraded_components"`
 	UnhealthyComponents int         `json:"unhealthy_components"`
-	UnknownComponents  int          `json:"unknown_components"`
-	OverallHealth      HealthState  `json:"overall_health"`
+	UnknownComponents   int         `json:"unknown_components"`
+	OverallHealth       HealthState `json:"overall_health"`
 }
 
 // HealthMonitor monitors the health of components
 type HealthMonitor interface {
 	// Start starts the health monitoring
 	Start(ctx context.Context) error
-	
+
 	// Stop stops the health monitoring
 	Stop() error
-	
+
 	// GetSystemHealth returns the current system health
 	GetSystemHealth(ctx context.Context, detailed bool) (*SystemHealth, error)
-	
+
 	// GetComponentHealth returns the health of a specific component
 	GetComponentHealth(ctx context.Context, name string, detailed bool) (*HealthStatus, error)
-	
+
 	// GetHealthHistory returns the health history of a component
 	GetHealthHistory(ctx context.Context, name string, since time.Time) ([]*HealthStatus, error)
-	
+
 	// Subscribe subscribes to health status changes
 	Subscribe(ctx context.Context, callback HealthChangeCallback) error
-	
+
 	// Unsubscribe unsubscribes from health status changes
 	Unsubscribe(callback HealthChangeCallback) error
 }
@@ -128,12 +128,12 @@ type HealthChangeCallback func(ctx context.Context, change *HealthChange)
 
 // HealthChange represents a change in health status
 type HealthChange struct {
-	Component   string      `json:"component"`
-	OldStatus   HealthState `json:"old_status"`
-	NewStatus   HealthState `json:"new_status"`
-	Timestamp   time.Time   `json:"timestamp"`
-	Message     string      `json:"message,omitempty"`
-	Details     map[string]interface{} `json:"details,omitempty"`
+	Component string                 `json:"component"`
+	OldStatus HealthState            `json:"old_status"`
+	NewStatus HealthState            `json:"new_status"`
+	Timestamp time.Time              `json:"timestamp"`
+	Message   string                 `json:"message,omitempty"`
+	Details   map[string]interface{} `json:"details,omitempty"`
 }
 
 // HealthCheckerFunc is a function that implements HealthChecker
@@ -162,13 +162,13 @@ func (f HealthCheckerFunc) GetVersion() string {
 // ServiceHealthChecker defines the interface for service-specific health checking
 type ServiceHealthChecker interface {
 	HealthChecker
-	
+
 	// CheckServiceHealth checks the health of the service
 	CheckServiceHealth(ctx context.Context, detailed bool) (*ServiceHealthStatus, error)
-	
+
 	// GetServiceMetrics returns service-specific metrics
 	GetServiceMetrics(ctx context.Context) (map[string]interface{}, error)
-	
+
 	// GetServiceDependencies returns the dependencies of the service
 	GetServiceDependencies() []string
 }
@@ -183,44 +183,44 @@ type ServiceHealthStatus struct {
 
 // ServicePerformance represents service performance metrics
 type ServicePerformance struct {
-	RequestRate      float64 `json:"request_rate,omitempty"`
-	ErrorRate        float64 `json:"error_rate,omitempty"`
-	Latency          float64 `json:"latency,omitempty"`
-	Throughput       float64 `json:"throughput,omitempty"`
-	CPUUsage         float64 `json:"cpu_usage,omitempty"`
-	MemoryUsage      float64 `json:"memory_usage,omitempty"`
-	DiskUsage        float64 `json:"disk_usage,omitempty"`
-	NetworkUsage     float64 `json:"network_usage,omitempty"`
+	RequestRate  float64 `json:"request_rate,omitempty"`
+	ErrorRate    float64 `json:"error_rate,omitempty"`
+	Latency      float64 `json:"latency,omitempty"`
+	Throughput   float64 `json:"throughput,omitempty"`
+	CPUUsage     float64 `json:"cpu_usage,omitempty"`
+	MemoryUsage  float64 `json:"memory_usage,omitempty"`
+	DiskUsage    float64 `json:"disk_usage,omitempty"`
+	NetworkUsage float64 `json:"network_usage,omitempty"`
 }
 
 // ServiceResources represents service resource usage
 type ServiceResources struct {
-	CPU        ResourceUsage `json:"cpu,omitempty"`
-	Memory     ResourceUsage `json:"memory,omitempty"`
-	Disk       ResourceUsage `json:"disk,omitempty"`
-	Network    ResourceUsage `json:"network,omitempty"`
+	CPU         ResourceUsage `json:"cpu,omitempty"`
+	Memory      ResourceUsage `json:"memory,omitempty"`
+	Disk        ResourceUsage `json:"disk,omitempty"`
+	Network     ResourceUsage `json:"network,omitempty"`
 	Connections ResourceUsage `json:"connections,omitempty"`
 }
 
 // ResourceUsage represents resource usage information
 type ResourceUsage struct {
-	Used      float64 `json:"used"`
-	Total     float64 `json:"total"`
-	Available float64 `json:"available"`
+	Used       float64 `json:"used"`
+	Total      float64 `json:"total"`
+	Available  float64 `json:"available"`
 	Percentage float64 `json:"percentage"`
-	Unit      string  `json:"unit"`
+	Unit       string  `json:"unit"`
 }
 
 // NodeHealthChecker defines the interface for node-specific health checking
 type NodeHealthChecker interface {
 	HealthChecker
-	
+
 	// CheckNodeHealth checks the health of the node
 	CheckNodeHealth(ctx context.Context, detailed bool) (*NodeHealthStatus, error)
-	
+
 	// GetNodeMetrics returns node-specific metrics
 	GetNodeMetrics(ctx context.Context) (map[string]interface{}, error)
-	
+
 	// GetNodeInfo returns node information
 	GetNodeInfo() *NodeInfo
 }
@@ -228,10 +228,10 @@ type NodeHealthChecker interface {
 // NodeHealthStatus represents the health status of a node
 type NodeHealthStatus struct {
 	HealthStatus
-	Hardware    *NodeHardware    `json:"hardware,omitempty"`
-	Network     *NodeNetwork     `json:"network,omitempty"`
-	Storage     *NodeStorage     `json:"storage,omitempty"`
-	Processes   []*NodeProcess   `json:"processes,omitempty"`
+	Hardware  *NodeHardware  `json:"hardware,omitempty"`
+	Network   *NodeNetwork   `json:"network,omitempty"`
+	Storage   *NodeStorage   `json:"storage,omitempty"`
+	Processes []*NodeProcess `json:"processes,omitempty"`
 }
 
 // NodeInfo represents node information
@@ -249,20 +249,20 @@ type NodeInfo struct {
 
 // NodeHardware represents node hardware information
 type NodeHardware struct {
-	CPU        CPUInfo        `json:"cpu,omitempty"`
-	Memory     MemoryInfo     `json:"memory,omitempty"`
-	Disk       DiskInfo       `json:"disk,omitempty"`
-	Network    NetworkInfo    `json:"network,omitempty"`
-	System     SystemInfo     `json:"system,omitempty"`
+	CPU     CPUInfo     `json:"cpu,omitempty"`
+	Memory  MemoryInfo  `json:"memory,omitempty"`
+	Disk    DiskInfo    `json:"disk,omitempty"`
+	Network NetworkInfo `json:"network,omitempty"`
+	System  SystemInfo  `json:"system,omitempty"`
 }
 
 // CPUInfo represents CPU information
 type CPUInfo struct {
-	Model      string  `json:"model,omitempty"`
-	Cores      int     `json:"cores,omitempty"`
-	Threads    int     `json:"threads,omitempty"`
-	Frequency  float64 `json:"frequency,omitempty"`
-	Usage      float64 `json:"usage,omitempty"`
+	Model       string  `json:"model,omitempty"`
+	Cores       int     `json:"cores,omitempty"`
+	Threads     int     `json:"threads,omitempty"`
+	Frequency   float64 `json:"frequency,omitempty"`
+	Usage       float64 `json:"usage,omitempty"`
 	Temperature float64 `json:"temperature,omitempty"`
 }
 
@@ -301,29 +301,29 @@ type NetworkInfo struct {
 
 // SystemInfo represents system information
 type SystemInfo struct {
-	Hostname   string `json:"hostname,omitempty"`
-	OS         string `json:"os,omitempty"`
-	Kernel     string `json:"kernel,omitempty"`
-	Arch       string `json:"arch,omitempty"`
-	Uptime     uint64 `json:"uptime,omitempty"`
-	LoadAvg    []float64 `json:"load_avg,omitempty"`
+	Hostname string    `json:"hostname,omitempty"`
+	OS       string    `json:"os,omitempty"`
+	Kernel   string    `json:"kernel,omitempty"`
+	Arch     string    `json:"arch,omitempty"`
+	Uptime   uint64    `json:"uptime,omitempty"`
+	LoadAvg  []float64 `json:"load_avg,omitempty"`
 }
 
 // NodeNetwork represents node network status
 type NodeNetwork struct {
 	Interfaces []*NetworkInterface `json:"interfaces,omitempty"`
-	Routing    []*Route           `json:"routing,omitempty"`
+	Routing    []*Route            `json:"routing,omitempty"`
 	Firewall   []*FirewallRule     `json:"firewall,omitempty"`
 }
 
 // NetworkInterface represents a network interface
 type NetworkInterface struct {
-	Name       string            `json:"name,omitempty"`
-	IP         string            `json:"ip,omitempty"`
-	MAC        string            `json:"mac,omitempty"`
-	Status     string            `json:"status,omitempty"`
-	Speed      float64           `json:"speed,omitempty"`
-	Metrics    map[string]uint64 `json:"metrics,omitempty"`
+	Name    string            `json:"name,omitempty"`
+	IP      string            `json:"ip,omitempty"`
+	MAC     string            `json:"mac,omitempty"`
+	Status  string            `json:"status,omitempty"`
+	Speed   float64           `json:"speed,omitempty"`
+	Metrics map[string]uint64 `json:"metrics,omitempty"`
 }
 
 // Route represents a network route
@@ -336,76 +336,76 @@ type Route struct {
 
 // FirewallRule represents a firewall rule
 type FirewallRule struct {
-	Action     string   `json:"action,omitempty"`
-	Protocol   string   `json:"protocol,omitempty"`
-	Source     string   `json:"source,omitempty"`
-	Destination string  `json:"destination,omitempty"`
-	Ports      []int    `json:"ports,omitempty"`
-	Enabled    bool     `json:"enabled,omitempty"`
+	Action      string `json:"action,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Destination string `json:"destination,omitempty"`
+	Ports       []int  `json:"ports,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
 }
 
 // NodeStorage represents node storage status
 type NodeStorage struct {
-	Devices    []*StorageDevice `json:"devices,omitempty"`
+	Devices     []*StorageDevice `json:"devices,omitempty"`
 	Filesystems []*Filesystem    `json:"filesystems,omitempty"`
-	Mounts     []*Mount         `json:"mounts,omitempty"`
+	Mounts      []*Mount         `json:"mounts,omitempty"`
 }
 
 // StorageDevice represents a storage device
 type StorageDevice struct {
-	Name       string            `json:"name,omitempty"`
-	Type       string            `json:"type,omitempty"`
-	Size       uint64            `json:"size,omitempty"`
-	Model      string            `json:"model,omitempty"`
-	Vendor     string            `json:"vendor,omitempty"`
-	Serial     string            `json:"serial,omitempty"`
-	Metrics    map[string]uint64 `json:"metrics,omitempty"`
+	Name    string            `json:"name,omitempty"`
+	Type    string            `json:"type,omitempty"`
+	Size    uint64            `json:"size,omitempty"`
+	Model   string            `json:"model,omitempty"`
+	Vendor  string            `json:"vendor,omitempty"`
+	Serial  string            `json:"serial,omitempty"`
+	Metrics map[string]uint64 `json:"metrics,omitempty"`
 }
 
 // Filesystem represents a filesystem
 type Filesystem struct {
-	Device     string  `json:"device,omitempty"`
-	Type       string  `json:"type,omitempty"`
-	Size       uint64  `json:"size,omitempty"`
-	Used       uint64  `json:"used,omitempty"`
-	Available  uint64  `json:"available,omitempty"`
-	Usage      float64 `json:"usage,omitempty"`
-	Mount      string  `json:"mount,omitempty"`
-	Options    []string `json:"options,omitempty"`
+	Device    string   `json:"device,omitempty"`
+	Type      string   `json:"type,omitempty"`
+	Size      uint64   `json:"size,omitempty"`
+	Used      uint64   `json:"used,omitempty"`
+	Available uint64   `json:"available,omitempty"`
+	Usage     float64  `json:"usage,omitempty"`
+	Mount     string   `json:"mount,omitempty"`
+	Options   []string `json:"options,omitempty"`
 }
 
 // Mount represents a mount point
 type Mount struct {
-	Device     string   `json:"device,omitempty"`
-	Mount      string   `json:"mount,omitempty"`
-	Type       string   `json:"type,omitempty"`
-	Options    []string `json:"options,omitempty"`
+	Device     string            `json:"device,omitempty"`
+	Mount      string            `json:"mount,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Options    []string          `json:"options,omitempty"`
 	Statistics map[string]uint64 `json:"statistics,omitempty"`
 }
 
 // NodeProcess represents a running process
 type NodeProcess struct {
-	PID        int               `json:"pid,omitempty"`
-	Name       string            `json:"name,omitempty"`
-	CPU        float64           `json:"cpu,omitempty"`
-	Memory     float64           `json:"memory,omitempty"`
-	Status     string            `json:"status,omitempty"`
-	User       string            `json:"user,omitempty"`
-	Command    string            `json:"command,omitempty"`
-	StartTime  time.Time         `json:"start_time,omitempty"`
-	Metrics    map[string]uint64 `json:"metrics,omitempty"`
+	PID       int               `json:"pid,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	CPU       float64           `json:"cpu,omitempty"`
+	Memory    float64           `json:"memory,omitempty"`
+	Status    string            `json:"status,omitempty"`
+	User      string            `json:"user,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	StartTime time.Time         `json:"start_time,omitempty"`
+	Metrics   map[string]uint64 `json:"metrics,omitempty"`
 }
 
 // ClusterHealthChecker defines the interface for cluster-specific health checking
 type ClusterHealthChecker interface {
 	HealthChecker
-	
+
 	// CheckClusterHealth checks the health of the cluster
 	CheckClusterHealth(ctx context.Context, detailed bool) (*ClusterHealthStatus, error)
-	
+
 	// GetClusterMetrics returns cluster-specific metrics
 	GetClusterMetrics(ctx context.Context) (map[string]interface{}, error)
-	
+
 	// GetClusterInfo returns cluster information
 	GetClusterInfo() *ClusterInfo
 }
@@ -413,10 +413,10 @@ type ClusterHealthChecker interface {
 // ClusterHealthStatus represents the health status of a cluster
 type ClusterHealthStatus struct {
 	HealthStatus
-	Nodes       map[string]*NodeHealthStatus `json:"nodes,omitempty"`
+	Nodes       map[string]*NodeHealthStatus    `json:"nodes,omitempty"`
 	Services    map[string]*ServiceHealthStatus `json:"services,omitempty"`
-	Replication *ClusterReplication          `json:"replication,omitempty"`
-	Partition   *ClusterPartition            `json:"partition,omitempty"`
+	Replication *ClusterReplication             `json:"replication,omitempty"`
+	Partition   *ClusterPartition               `json:"partition,omitempty"`
 }
 
 // ClusterInfo represents cluster information
@@ -454,25 +454,25 @@ type ClusterPartition struct {
 type HealthCheckBuilder interface {
 	// Name sets the name of the health checker
 	Name(name string) HealthCheckBuilder
-	
+
 	// Component sets the component being checked
 	Component(component string) HealthCheckBuilder
-	
+
 	// Version sets the version of the component
 	Version(version string) HealthCheckBuilder
-	
+
 	// Check sets the check function
 	Check(check HealthCheckerFunc) HealthCheckBuilder
-	
+
 	// Timeout sets the timeout for the health check
 	Timeout(timeout time.Duration) HealthCheckBuilder
-	
+
 	// Interval sets the interval for health checks
 	Interval(interval time.Duration) HealthCheckBuilder
-	
+
 	// Dependencies sets the dependencies of the health checker
 	Dependencies(dependencies []string) HealthCheckBuilder
-	
+
 	// Build builds the health checker
 	Build() HealthChecker
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -12,17 +12,17 @@ type Logger = zap.Logger
 func NewLogger() (*zap.Logger, error) {
 	// Configure zap logger with production settings
 	config := zap.NewProductionConfig()
-	
+
 	// Adjust configuration as needed
 	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	config.OutputPaths = []string{"stdout"}
 	config.ErrorOutputPaths = []string{"stderr"}
-	
+
 	// Build the logger
 	logger, err := config.Build()
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return logger, nil
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -3,7 +3,7 @@ package logging_test
 import (
 	"testing"
 
-	"vexdb/internal/logging"
+	"vxdb/internal/logging"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -350,7 +350,7 @@ func (m *Metrics) GetConfig() *Config {
 		Enabled:   true,
 		Port:      9090,
 		Path:      "/metrics",
-		Namespace: "vexdb",
+		Namespace: "vxdb",
 		Subsystem: "",
 		Interval:  15 * time.Second,
 		Buckets:   prometheus.DefBuckets,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,7 +16,7 @@ func TestNewMetrics_DefaultConfig(t *testing.T) {
 		t.Fatal("registry should not be nil")
 	}
 	cfg := m.GetConfig()
-	if cfg.Path != "/metrics" || cfg.Namespace != "vexdb" {
+	if cfg.Path != "/metrics" || cfg.Namespace != "vxdb" {
 		t.Fatalf("unexpected default config: %#v", cfg)
 	}
 }

--- a/internal/monitoring/collector.go
+++ b/internal/monitoring/collector.go
@@ -148,7 +148,7 @@ func NewCollector(logger *zap.Logger, config *Config) *Collector {
 func DefaultConfig() *Config {
 	return &Config{
 		Enabled:             true,
-		Namespace:           "vexdb",
+		Namespace:           "vxdb",
 		Subsystem:           "",
 		CollectInterval:     15 * time.Second,
 		HealthCheckInterval: 30 * time.Second,
@@ -156,7 +156,7 @@ func DefaultConfig() *Config {
 		ProfilingPort:       6060,
 		EnableTracing:       false,
 		TracingEndpoint:     "",
-		ServiceName:         "vexdb",
+		ServiceName:         "vxdb",
 		ServiceVersion:      "1.0.0",
 		ServiceInstance:     "default",
 	}

--- a/internal/monitoring/dashboard.go
+++ b/internal/monitoring/dashboard.go
@@ -189,7 +189,7 @@ func (d *Dashboard) handleDashboard(w http.ResponseWriter, r *http.Request) {
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Dashboard</title>
+    <title>VxDB Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -202,7 +202,7 @@ func (d *Dashboard) handleDashboard(w http.ResponseWriter, r *http.Request) {
     </style>
 </head>
 <body>
-    <h1>VexDB Dashboard</h1>
+    <h1>VxDB Dashboard</h1>
     <div class="nav">
         <a href="/dashboard/overview">Overview</a>
         <a href="/dashboard/search">Search</a>
@@ -254,7 +254,7 @@ func (d *Dashboard) handleOverview(w http.ResponseWriter, r *http.Request) {
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Overview</title>
+    <title>VxDB Overview</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -264,7 +264,7 @@ func (d *Dashboard) handleOverview(w http.ResponseWriter, r *http.Request) {
     </style>
 </head>
 <body>
-    <h1>VexDB Overview</h1>
+    <h1>VxDB Overview</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -326,7 +326,7 @@ func (d *Dashboard) handleSearchDashboard(w http.ResponseWriter, r *http.Request
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Search Dashboard</title>
+    <title>VxDB Search Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -336,7 +336,7 @@ func (d *Dashboard) handleSearchDashboard(w http.ResponseWriter, r *http.Request
     </style>
 </head>
 <body>
-    <h1>VexDB Search Dashboard</h1>
+    <h1>VxDB Search Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -376,7 +376,7 @@ func (d *Dashboard) handleStorageDashboard(w http.ResponseWriter, r *http.Reques
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Storage Dashboard</title>
+    <title>VxDB Storage Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -386,7 +386,7 @@ func (d *Dashboard) handleStorageDashboard(w http.ResponseWriter, r *http.Reques
     </style>
 </head>
 <body>
-    <h1>VexDB Storage Dashboard</h1>
+    <h1>VxDB Storage Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -438,7 +438,7 @@ func (d *Dashboard) handleClusterDashboard(w http.ResponseWriter, r *http.Reques
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Cluster Dashboard</title>
+    <title>VxDB Cluster Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -449,7 +449,7 @@ func (d *Dashboard) handleClusterDashboard(w http.ResponseWriter, r *http.Reques
     </style>
 </head>
 <body>
-    <h1>VexDB Cluster Dashboard</h1>
+    <h1>VxDB Cluster Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -504,7 +504,7 @@ func (d *Dashboard) handleSystemDashboard(w http.ResponseWriter, r *http.Request
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB System Dashboard</title>
+    <title>VxDB System Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -514,7 +514,7 @@ func (d *Dashboard) handleSystemDashboard(w http.ResponseWriter, r *http.Request
     </style>
 </head>
 <body>
-    <h1>VexDB System Dashboard</h1>
+    <h1>VxDB System Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -578,7 +578,7 @@ func (d *Dashboard) handleReplicationDashboard(w http.ResponseWriter, r *http.Re
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Replication Dashboard</title>
+    <title>VxDB Replication Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -588,7 +588,7 @@ func (d *Dashboard) handleReplicationDashboard(w http.ResponseWriter, r *http.Re
     </style>
 </head>
 <body>
-    <h1>VexDB Replication Dashboard</h1>
+    <h1>VxDB Replication Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -653,7 +653,7 @@ func (d *Dashboard) handleCacheDashboard(w http.ResponseWriter, r *http.Request)
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Cache Dashboard</title>
+    <title>VxDB Cache Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -663,7 +663,7 @@ func (d *Dashboard) handleCacheDashboard(w http.ResponseWriter, r *http.Request)
     </style>
 </head>
 <body>
-    <h1>VexDB Cache Dashboard</h1>
+    <h1>VxDB Cache Dashboard</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>
@@ -769,7 +769,7 @@ func (d *Dashboard) handleDebug(w http.ResponseWriter, r *http.Request) {
 <!DOCTYPE html>
 <html>
 <head>
-    <title>VexDB Debug</title>
+    <title>VxDB Debug</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .nav { margin-bottom: 30px; }
@@ -778,7 +778,7 @@ func (d *Dashboard) handleDebug(w http.ResponseWriter, r *http.Request) {
     </style>
 </head>
 <body>
-    <h1>VexDB Debug</h1>
+    <h1>VxDB Debug</h1>
     <div class="nav">
         <a href="/dashboard">← Back</a>
     </div>

--- a/internal/monitoring/tracing.go
+++ b/internal/monitoring/tracing.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Tracer manages distributed tracing for the VexDB system
+// Tracer manages distributed tracing for the VxDB system
 type Tracer struct {
 	logger       *zap.Logger
 	config       *TracingConfig
@@ -44,7 +44,7 @@ type TracingConfig struct {
 func DefaultTracingConfig() *TracingConfig {
 	return &TracingConfig{
 		Enabled:      false,
-		ServiceName:  "vexdb",
+		ServiceName:  "vxdb",
 		Endpoint:     "http://localhost:14268/api/traces",
 		SamplingRate: 0.1, // 10% sampling
 		BatchSize:    512,

--- a/internal/protocol/adapter/interface.go
+++ b/internal/protocol/adapter/interface.go
@@ -7,9 +7,9 @@ import (
 	"math/rand"
 	"time"
 
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 var (

--- a/internal/protocol/backpressure/handler.go
+++ b/internal/protocol/backpressure/handler.go
@@ -10,10 +10,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 var (

--- a/internal/protocol/connection/manager.go
+++ b/internal/protocol/connection/manager.go
@@ -9,10 +9,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 var (
@@ -254,10 +254,10 @@ func (m *ConnectionManager) Stop() error {
 		return ErrManagerNotRunning
 	}
 
-        // Close all connections
-        if err := m.closeAllConnectionsLocked(); err != nil {
-                m.logger.Error("Failed to close all connections", zap.Error(err))
-        }
+	// Close all connections
+	if err := m.closeAllConnectionsLocked(); err != nil {
+		m.logger.Error("Failed to close all connections", zap.Error(err))
+	}
 
 	// Stop cleanup routine
 	close(m.cleanupChan)
@@ -451,22 +451,22 @@ func (m *ConnectionManager) CloseConnection(connID string) error {
 
 // CloseAllConnections closes all connections
 func (m *ConnectionManager) CloseAllConnections() error {
-        m.mu.Lock()
-        defer m.mu.Unlock()
-        return m.closeAllConnectionsLocked()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeAllConnectionsLocked()
 }
 
 // closeAllConnectionsLocked assumes the mutex is already held and marks all connections inactive.
 func (m *ConnectionManager) closeAllConnectionsLocked() error {
-        if m.config.EnableLogging {
-                m.logger.Info("Closing all connections", zap.Int("count", len(m.connections)))
-        }
+	if m.config.EnableLogging {
+		m.logger.Info("Closing all connections", zap.Int("count", len(m.connections)))
+	}
 
-        for _, conn := range m.connections {
-                conn.Active = false
-        }
+	for _, conn := range m.connections {
+		conn.Active = false
+	}
 
-        return nil
+	return nil
 }
 
 // GetStats returns connection manager statistics

--- a/internal/protocol/connection/manager_test.go
+++ b/internal/protocol/connection/manager_test.go
@@ -1,175 +1,174 @@
 package connection
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 
-    "go.uber.org/zap"
-    "vexdb/internal/protocol/adapter"
+	"go.uber.org/zap"
+	"vxdb/internal/protocol/adapter"
 )
 
 func TestValidateConnectionManagerConfig(t *testing.T) {
-    cfg := DefaultConnectionManagerConfig()
-    if err := validateConnectionManagerConfig(cfg); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
+	cfg := DefaultConnectionManagerConfig()
+	if err := validateConnectionManagerConfig(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-    bad := *cfg
-    bad.MaxConnections = 0
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for max connections")
-    }
+	bad := *cfg
+	bad.MaxConnections = 0
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for max connections")
+	}
 
-    bad = *cfg
-    bad.IdleTimeout = 0
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for idle timeout")
-    }
+	bad = *cfg
+	bad.IdleTimeout = 0
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for idle timeout")
+	}
 
-    bad = *cfg
-    bad.ReadTimeout = -1
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for read timeout")
-    }
+	bad = *cfg
+	bad.ReadTimeout = -1
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for read timeout")
+	}
 
-    bad = *cfg
-    bad.WriteTimeout = -1
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for write timeout")
-    }
+	bad = *cfg
+	bad.WriteTimeout = -1
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for write timeout")
+	}
 
-    bad = *cfg
-    bad.CleanupInterval = 0
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for cleanup interval")
-    }
+	bad = *cfg
+	bad.CleanupInterval = 0
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for cleanup interval")
+	}
 
-    bad = *cfg
-    bad.BufferSize = 0
-    if err := validateConnectionManagerConfig(&bad); err == nil {
-        t.Errorf("expected error for buffer size")
-    }
+	bad = *cfg
+	bad.BufferSize = 0
+	if err := validateConnectionManagerConfig(&bad); err == nil {
+		t.Errorf("expected error for buffer size")
+	}
 }
 
 func newTestConnection(id string) *adapter.Connection {
-    now := time.Now()
-    return &adapter.Connection{
-        ID:           id,
-        RemoteAddr:   "127.0.0.1",
-        LocalAddr:    "",
-        Protocol:     adapter.ProtocolHTTP,
-        Established:  now,
-        LastActivity: now,
-        Active:       true,
-    }
+	now := time.Now()
+	return &adapter.Connection{
+		ID:           id,
+		RemoteAddr:   "127.0.0.1",
+		LocalAddr:    "",
+		Protocol:     adapter.ProtocolHTTP,
+		Established:  now,
+		LastActivity: now,
+		Active:       true,
+	}
 }
 
 func TestConnectionManagerLifecycle(t *testing.T) {
-    baseLogger := zap.NewNop()
-    manager, err := NewConnectionManager(nil, *baseLogger, nil)
-    if err != nil {
-        t.Fatalf("failed to create manager: %v", err)
-    }
+	baseLogger := zap.NewNop()
+	manager, err := NewConnectionManager(nil, *baseLogger, nil)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
 
-    if err := manager.Start(); err != nil {
-        t.Fatalf("start failed: %v", err)
-    }
-    t.Log("started")
-    if !manager.IsRunning() {
-        t.Fatal("manager should be running")
-    }
-    if err := manager.Start(); err != ErrManagerAlreadyRunning {
-        t.Errorf("expected ErrManagerAlreadyRunning, got %v", err)
-    }
-    t.Log("double start checked")
+	if err := manager.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	t.Log("started")
+	if !manager.IsRunning() {
+		t.Fatal("manager should be running")
+	}
+	if err := manager.Start(); err != ErrManagerAlreadyRunning {
+		t.Errorf("expected ErrManagerAlreadyRunning, got %v", err)
+	}
+	t.Log("double start checked")
 
-    cfg := manager.GetConfig()
-    cfg.MaxConnections = 1
-    if err := manager.UpdateConfig(cfg); err != nil {
-        t.Fatalf("update config: %v", err)
-    }
-    t.Log("config updated")
+	cfg := manager.GetConfig()
+	cfg.MaxConnections = 1
+	if err := manager.UpdateConfig(cfg); err != nil {
+		t.Fatalf("update config: %v", err)
+	}
+	t.Log("config updated")
 
-    c1 := newTestConnection("c1")
-    if err := manager.AddConnection(c1); err != nil {
-        t.Fatalf("add first connection: %v", err)
-    }
-    t.Log("added first connection")
-    c2 := newTestConnection("c2")
-    if err := manager.AddConnection(c2); err != ErrConnectionLimitExceeded {
-        t.Errorf("expected limit error, got %v", err)
-    }
-    t.Log("limit enforced")
+	c1 := newTestConnection("c1")
+	if err := manager.AddConnection(c1); err != nil {
+		t.Fatalf("add first connection: %v", err)
+	}
+	t.Log("added first connection")
+	c2 := newTestConnection("c2")
+	if err := manager.AddConnection(c2); err != ErrConnectionLimitExceeded {
+		t.Errorf("expected limit error, got %v", err)
+	}
+	t.Log("limit enforced")
 
-    got, ok := manager.GetConnection("c1")
-    if !ok || got.ID != "c1" {
-        t.Fatalf("expected to retrieve connection c1")
-    }
-    t.Log("retrieved connection")
+	got, ok := manager.GetConnection("c1")
+	if !ok || got.ID != "c1" {
+		t.Fatalf("expected to retrieve connection c1")
+	}
+	t.Log("retrieved connection")
 
-    manager.UpdateConnectionStats("c1", 10, 20, 1)
-    if got.BytesRead != 10 || got.BytesWritten != 20 || got.Requests != 1 {
-        t.Errorf("unexpected connection stats: %+v", got)
-    }
-    stats := manager.GetStats()
-    if stats.TotalBytesRead != 10 || stats.TotalBytesWritten != 20 || stats.TotalRequests != 1 {
-        t.Errorf("unexpected manager stats: %+v", stats)
-    }
-    t.Log("stats updated")
+	manager.UpdateConnectionStats("c1", 10, 20, 1)
+	if got.BytesRead != 10 || got.BytesWritten != 20 || got.Requests != 1 {
+		t.Errorf("unexpected connection stats: %+v", got)
+	}
+	stats := manager.GetStats()
+	if stats.TotalBytesRead != 10 || stats.TotalBytesWritten != 20 || stats.TotalRequests != 1 {
+		t.Errorf("unexpected manager stats: %+v", stats)
+	}
+	t.Log("stats updated")
 
-    if err := manager.CloseConnection("c1"); err != nil {
-        t.Fatalf("close connection: %v", err)
-    }
-    if got.Active {
-        t.Error("connection should be inactive after close")
-    }
-    t.Log("connection closed")
+	if err := manager.CloseConnection("c1"); err != nil {
+		t.Fatalf("close connection: %v", err)
+	}
+	if got.Active {
+		t.Error("connection should be inactive after close")
+	}
+	t.Log("connection closed")
 
-    if err := manager.RemoveConnection("c1"); err != nil {
-        t.Fatalf("remove connection: %v", err)
-    }
-    if _, ok := manager.GetConnection("c1"); ok {
-        t.Error("connection should be removed")
-    }
-    if err := manager.RemoveConnection("missing"); err != ErrConnectionNotFound {
-        t.Errorf("expected ErrConnectionNotFound, got %v", err)
-    }
-    t.Log("removal validated")
+	if err := manager.RemoveConnection("c1"); err != nil {
+		t.Fatalf("remove connection: %v", err)
+	}
+	if _, ok := manager.GetConnection("c1"); ok {
+		t.Error("connection should be removed")
+	}
+	if err := manager.RemoveConnection("missing"); err != ErrConnectionNotFound {
+		t.Errorf("expected ErrConnectionNotFound, got %v", err)
+	}
+	t.Log("removal validated")
 
-    if err := manager.Stop(); err != nil {
-        t.Fatalf("stop failed: %v", err)
-    }
-    if manager.IsRunning() {
-        t.Error("manager should not be running")
-    }
-    if err := manager.Stop(); err != nil {
-        t.Fatalf("second stop should be nil, got %v", err)
-    }
-    t.Log("stopped")
+	if err := manager.Stop(); err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+	if manager.IsRunning() {
+		t.Error("manager should not be running")
+	}
+	if err := manager.Stop(); err != nil {
+		t.Fatalf("second stop should be nil, got %v", err)
+	}
+	t.Log("stopped")
 }
 
 func TestCloseAllConnections(t *testing.T) {
-    baseLogger := zap.NewNop()
-    manager, err := NewConnectionManager(nil, *baseLogger, nil)
-    if err != nil {
-        t.Fatalf("create manager: %v", err)
-    }
-    if err := manager.Start(); err != nil {
-        t.Fatalf("start manager: %v", err)
-    }
+	baseLogger := zap.NewNop()
+	manager, err := NewConnectionManager(nil, *baseLogger, nil)
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+	if err := manager.Start(); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
 
-    c1 := newTestConnection("a")
-    c2 := newTestConnection("b")
-    manager.AddConnection(c1)
-    manager.AddConnection(c2)
+	c1 := newTestConnection("a")
+	c2 := newTestConnection("b")
+	manager.AddConnection(c1)
+	manager.AddConnection(c2)
 
-    if err := manager.CloseAllConnections(); err != nil {
-        t.Fatalf("close all connections: %v", err)
-    }
-    for _, c := range manager.GetAllConnections() {
-        if c.Active {
-            t.Errorf("connection %s should be inactive", c.ID)
-        }
-    }
+	if err := manager.CloseAllConnections(); err != nil {
+		t.Fatalf("close all connections: %v", err)
+	}
+	for _, c := range manager.GetAllConnections() {
+		if c.Active {
+			t.Errorf("connection %s should be inactive", c.ID)
+		}
+	}
 }
-

--- a/internal/protocol/error/handler.go
+++ b/internal/protocol/error/handler.go
@@ -12,10 +12,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 var (

--- a/internal/protocol/grpc/adapter.go
+++ b/internal/protocol/grpc/adapter.go
@@ -12,10 +12,10 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 // GRPCAdapter implements the ProtocolAdapter interface for gRPC

--- a/internal/protocol/grpc/adapter_test.go
+++ b/internal/protocol/grpc/adapter_test.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"vexdb/internal/metrics"
+	"vxdb/internal/metrics"
 )
 
 // getFreePort returns an available TCP port for testing.

--- a/internal/protocol/health/monitor.go
+++ b/internal/protocol/health/monitor.go
@@ -1,4 +1,3 @@
-
 package health
 
 import (
@@ -6,23 +5,23 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
 	"go.uber.org/zap"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
 )
 
 // ConnectionHealthMonitor monitors the health of protocol connections
 type ConnectionHealthMonitor struct {
-	logger          logging.Logger
-	metrics         *metrics.IngestionMetrics
-	checkInterval   time.Duration
-	timeout         time.Duration
-	healthyThreshold int
+	logger             logging.Logger
+	metrics            *metrics.IngestionMetrics
+	checkInterval      time.Duration
+	timeout            time.Duration
+	healthyThreshold   int
 	unhealthyThreshold int
-	mu              sync.RWMutex
-	connections     map[string]*ConnectionHealth
-	shutdown        chan struct{}
-	wg              sync.WaitGroup
+	mu                 sync.RWMutex
+	connections        map[string]*ConnectionHealth
+	shutdown           chan struct{}
+	wg                 sync.WaitGroup
 }
 
 // ConnectionHealth represents the health status of a connection
@@ -69,20 +68,20 @@ func (s ConnectionStatus) String() string {
 // MonitorConfig represents the configuration for the connection health monitor
 type MonitorConfig struct {
 	CheckInterval      time.Duration `yaml:"check_interval" json:"check_interval"`
-	Timeout           time.Duration `yaml:"timeout" json:"timeout"`
-	HealthyThreshold  int           `yaml:"healthy_threshold" json:"healthy_threshold"`
-	UnhealthyThreshold int          `yaml:"unhealthy_threshold" json:"unhealthy_threshold"`
-	EnableMetrics     bool          `yaml:"enable_metrics" json:"enable_metrics"`
+	Timeout            time.Duration `yaml:"timeout" json:"timeout"`
+	HealthyThreshold   int           `yaml:"healthy_threshold" json:"healthy_threshold"`
+	UnhealthyThreshold int           `yaml:"unhealthy_threshold" json:"unhealthy_threshold"`
+	EnableMetrics      bool          `yaml:"enable_metrics" json:"enable_metrics"`
 }
 
 // DefaultMonitorConfig returns the default monitor configuration
 func DefaultMonitorConfig() *MonitorConfig {
 	return &MonitorConfig{
 		CheckInterval:      30 * time.Second,
-		Timeout:           5 * time.Second,
-		HealthyThreshold:  3,
+		Timeout:            5 * time.Second,
+		HealthyThreshold:   3,
 		UnhealthyThreshold: 5,
-		EnableMetrics:     true,
+		EnableMetrics:      true,
 	}
 }
 
@@ -93,14 +92,14 @@ func NewConnectionHealthMonitor(config *MonitorConfig, logger logging.Logger, me
 	}
 
 	monitor := &ConnectionHealthMonitor{
-		logger:            logger,
-		metrics:           metrics,
-		checkInterval:     config.CheckInterval,
-		timeout:           config.Timeout,
-		healthyThreshold:  config.HealthyThreshold,
+		logger:             logger,
+		metrics:            metrics,
+		checkInterval:      config.CheckInterval,
+		timeout:            config.Timeout,
+		healthyThreshold:   config.HealthyThreshold,
 		unhealthyThreshold: config.UnhealthyThreshold,
-		connections:       make(map[string]*ConnectionHealth),
-		shutdown:          make(chan struct{}),
+		connections:        make(map[string]*ConnectionHealth),
+		shutdown:           make(chan struct{}),
 	}
 
 	monitor.logger.Info("Created connection health monitor",
@@ -291,7 +290,6 @@ func (m *ConnectionHealthMonitor) runHealthChecks(ctx context.Context) {
 
 	ticker := time.NewTicker(m.checkInterval)
 	defer ticker.Stop()
-
 
 	for {
 		select {

--- a/internal/protocol/health/monitor_test.go
+++ b/internal/protocol/health/monitor_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/metrics"
+	"vxdb/internal/metrics"
 )
 
 func TestDefaultMonitorConfig(t *testing.T) {

--- a/internal/protocol/http/adapter.go
+++ b/internal/protocol/http/adapter.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
+	"vxdb/internal/types"
 )
 
 // HTTPAdapter implements the ProtocolAdapter interface for HTTP REST API

--- a/internal/protocol/metrics/collector.go
+++ b/internal/protocol/metrics/collector.go
@@ -12,10 +12,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 var (

--- a/internal/protocol/rate/limiter.go
+++ b/internal/protocol/rate/limiter.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 
 	"go.uber.org/zap"
 )

--- a/internal/protocol/redis/adapter.go
+++ b/internal/protocol/redis/adapter.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 // RedisAdapter implements the ProtocolAdapter interface for Redis protocol (RESP)

--- a/internal/protocol/validation/protocol_validator.go
+++ b/internal/protocol/validation/protocol_validator.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 // ProtocolValidator handles protocol-specific validation
@@ -59,7 +59,7 @@ func NewProtocolValidator() *ProtocolValidator {
 		websocketRules: &WebSocketValidationRules{
 			MaxMessageSize:       10 << 20, // 10MB
 			AllowedOrigins:       []string{"*"},
-			RequiredSubprotocols: []string{"vexdb-v1"},
+			RequiredSubprotocols: []string{"vxdb-v1"},
 		},
 		grpcRules: &GRPCValidationRules{
 			MaxMessageSize:  4 << 20, // 4MB

--- a/internal/protocol/validation/validator.go
+++ b/internal/protocol/validation/validator.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
 )
 
 var (

--- a/internal/protocol/websocket/adapter.go
+++ b/internal/protocol/websocket/adapter.go
@@ -12,11 +12,11 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/protocol/adapter"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/protocol/adapter"
+	"vxdb/internal/types"
 )
 
 // WebSocketAdapter implements the ProtocolAdapter interface for WebSocket streaming

--- a/internal/routing/consistent_hash.go
+++ b/internal/routing/consistent_hash.go
@@ -1,4 +1,3 @@
-
 package routing
 
 import (
@@ -145,10 +144,10 @@ func (r *ConsistentHashRing) GetNodes(key string, count int) []string {
 
 // GetNodeCount returns the number of nodes in the ring
 func (r *ConsistentHashRing) GetNodeCount() int {
-    r.mu.RLock()
-    defer r.mu.RUnlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
-    return len(r.nodeMap)
+	return len(r.nodeMap)
 }
 
 // GetAllNodes returns all nodes in the ring

--- a/internal/routing/engine.go
+++ b/internal/routing/engine.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 // RoutingEngine handles cluster routing and node selection

--- a/internal/routing/replication.go
+++ b/internal/routing/replication.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 // ReplicationManager handles replication of vectors across multiple nodes
@@ -28,11 +28,11 @@ type ReplicationManager struct {
 
 // ReplicationPool manages a pool of workers for concurrent replication
 type ReplicationPool struct {
-        workers    []*ReplicationWorker
-        taskQueue  chan *ReplicationTask
-        resultChan chan *ReplicationResult
-        logger     logging.Logger
-        mu         sync.RWMutex
+	workers    []*ReplicationWorker
+	taskQueue  chan *ReplicationTask
+	resultChan chan *ReplicationResult
+	logger     logging.Logger
+	mu         sync.RWMutex
 }
 
 // ReplicationWorker represents a worker that handles replication tasks
@@ -327,11 +327,11 @@ func (m *ReplicationManager) monitorCircuitBreakers() {
 
 // NewReplicationPool creates a new replication pool
 func NewReplicationPool(workerCount int, logger logging.Logger, metrics *metrics.IngestionMetrics) *ReplicationPool {
-        pool := &ReplicationPool{
-                taskQueue:  make(chan *ReplicationTask, 1000),
-                resultChan: make(chan *ReplicationResult, 1000),
-                logger:     logger,
-        }
+	pool := &ReplicationPool{
+		taskQueue:  make(chan *ReplicationTask, 1000),
+		resultChan: make(chan *ReplicationResult, 1000),
+		logger:     logger,
+	}
 
 	// Create workers
 	for i := 0; i < workerCount; i++ {

--- a/internal/search/PHASE_11_TESTING_SUMMARY.md
+++ b/internal/search/PHASE_11_TESTING_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Phase 11 of the VEXDB project has been successfully completed with comprehensive testing infrastructure for the search service. This phase focused on creating robust unit tests, integration tests, performance benchmarks, and test utilities to ensure code quality, reliability, and performance validation.
+Phase 11 of the VXDB project has been successfully completed with comprehensive testing infrastructure for the search service. This phase focused on creating robust unit tests, integration tests, performance benchmarks, and test utilities to ensure code quality, reliability, and performance validation.
 
 ## Completed Components
 
@@ -321,7 +321,7 @@ Phase 11 has been successfully completed with a comprehensive testing infrastruc
 4. **Production Readiness**: Thread-safe operations and proper resource management
 5. **Integration Confidence**: Comprehensive testing of both HTTP and gRPC interfaces
 
-The testing infrastructure ensures that the VEXDB search service implemented in Phase 10 is robust, performant, and ready for production deployment. The comprehensive test suite provides confidence in the system's reliability and serves as a foundation for continuous integration and deployment pipelines.
+The testing infrastructure ensures that the VXDB search service implemented in Phase 10 is robust, performant, and ready for production deployment. The comprehensive test suite provides confidence in the system's reliability and serves as a foundation for continuous integration and deployment pipelines.
 
 ## Next Steps
 

--- a/internal/search/api/handlers.go
+++ b/internal/search/api/handlers.go
@@ -1,21 +1,21 @@
 package api
 
 import (
-    "encoding/json"
-    "fmt"
-    "io"
-    "net/http"
-    "time"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
 
-    "vexdb/internal/metrics"
-    "vexdb/internal/search/config"
-    "vexdb/internal/search/response"
-    "vexdb/internal/search/validation"
-    "vexdb/internal/service"
-    "vexdb/internal/types"
+	"vxdb/internal/metrics"
+	"vxdb/internal/search/config"
+	"vxdb/internal/search/response"
+	"vxdb/internal/search/validation"
+	"vxdb/internal/service"
+	"vxdb/internal/types"
 
-    "github.com/gorilla/mux"
-    "go.uber.org/zap"
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
 )
 
 // SearchHandler handles HTTP search requests
@@ -36,7 +36,7 @@ func NewSearchHandler(cfg *config.SearchServiceConfig, logger *zap.Logger, metri
 		cfg.Engine.MaxResults,
 		100, // maxMetadataFilters
 	)
-	
+
 	formatter := response.NewFormatter(&response.ResponseConfig{
 		IncludeQueryVector: cfg.API.Response.IncludeQueryVector,
 		IncludeMetadata:    cfg.API.Response.IncludeMetadata,
@@ -107,11 +107,11 @@ func (h *SearchHandler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert to internal types
-    queryVector := &types.Vector{
-        ID:       request.VectorID,
-        Data:     toFloat32(request.Vector),
-        Metadata: toMetadata(request.Metadata),
-    }
+	queryVector := &types.Vector{
+		ID:       request.VectorID,
+		Data:     toFloat32(request.Vector),
+		Metadata: toMetadata(request.Metadata),
+	}
 
 	// Set default k if not provided
 	k := request.K
@@ -161,21 +161,21 @@ func (h *SearchHandler) handleSimilaritySearch(w http.ResponseWriter, r *http.Re
 	}
 
 	// Convert to internal types
-    queryVector := &types.Vector{
-        ID:       request.VectorID,
-        Data:     toFloat32(request.Vector),
-        Metadata: toMetadata(request.Metadata),
-    }
+	queryVector := &types.Vector{
+		ID:       request.VectorID,
+		Data:     toFloat32(request.Vector),
+		Metadata: toMetadata(request.Metadata),
+	}
 
 	// Build metadata filter if provided
-    var filter *types.MetadataFilter
-    if len(request.Filters) > 0 {
-        filter = &types.MetadataFilter{Conditions: make([]interface{}, 0, len(request.Filters))}
-        for _, f := range request.Filters {
-            cond := &types.MetadataCondition{Key: f.Key, Operator: f.Operator, Value: f.Value, Values: f.Values}
-            filter.Conditions = append(filter.Conditions, cond)
-        }
-    }
+	var filter *types.MetadataFilter
+	if len(request.Filters) > 0 {
+		filter = &types.MetadataFilter{Conditions: make([]interface{}, 0, len(request.Filters))}
+		for _, f := range request.Filters {
+			cond := &types.MetadataCondition{Key: f.Key, Operator: f.Operator, Value: f.Value, Values: f.Values}
+			filter.Conditions = append(filter.Conditions, cond)
+		}
+	}
 
 	// Set default k if not provided
 	k := request.K
@@ -235,11 +235,11 @@ func (h *SearchHandler) handleBatchSearch(w http.ResponseWriter, r *http.Request
 	var stats []*response.SearchStats
 
 	for i, query := range request.Queries {
-        queryVector := &types.Vector{
-            ID:       query.VectorID,
-            Data:     toFloat32(query.Vector),
-            Metadata: toMetadata(query.Metadata),
-        }
+		queryVector := &types.Vector{
+			ID:       query.VectorID,
+			Data:     toFloat32(query.Vector),
+			Metadata: toMetadata(query.Metadata),
+		}
 
 		k := query.K
 		if k <= 0 {
@@ -255,7 +255,7 @@ func (h *SearchHandler) handleBatchSearch(w http.ResponseWriter, r *http.Request
 
 		allResults = append(allResults, results)
 		queryIDs = append(queryIDs, fmt.Sprintf("%s_%d", queryID, i))
-		
+
 		stats = append(stats, &response.SearchStats{
 			TotalResults:    len(results),
 			ReturnedResults: len(results),
@@ -292,11 +292,11 @@ func (h *SearchHandler) handleMultiClusterSearch(w http.ResponseWriter, r *http.
 	}
 
 	// Convert to internal types
-    queryVector := &types.Vector{
-        ID:       request.VectorID,
-        Data:     toFloat32(request.Vector),
-        Metadata: toMetadata(request.Metadata),
-    }
+	queryVector := &types.Vector{
+		ID:       request.VectorID,
+		Data:     toFloat32(request.Vector),
+		Metadata: toMetadata(request.Metadata),
+	}
 
 	// Set default k if not provided
 	k := request.K
@@ -366,7 +366,7 @@ func (h *SearchHandler) handleListClusters(w http.ResponseWriter, r *http.Reques
 // handleGetCluster handles get cluster requests
 func (h *SearchHandler) handleGetCluster(w http.ResponseWriter, r *http.Request) {
 	queryID := generateQueryID()
-    _ = mux.Vars(r)["id"]
+	_ = mux.Vars(r)["id"]
 
 	// For now, return not implemented
 	h.handleError(w, r, fmt.Errorf("get cluster not implemented"), queryID, "NOT_IMPLEMENTED")
@@ -375,7 +375,7 @@ func (h *SearchHandler) handleGetCluster(w http.ResponseWriter, r *http.Request)
 // handleClusterSearch handles cluster-specific search requests
 func (h *SearchHandler) handleClusterSearch(w http.ResponseWriter, r *http.Request) {
 	queryID := generateQueryID()
-    _ = mux.Vars(r)["id"]
+	_ = mux.Vars(r)["id"]
 
 	// For now, return not implemented
 	h.handleError(w, r, fmt.Errorf("cluster search not implemented"), queryID, "NOT_IMPLEMENTED")
@@ -393,8 +393,8 @@ func (h *SearchHandler) handleHealthCheck(w http.ResponseWriter, r *http.Request
 	}
 
 	response := h.formatter.FormatHealthResponse(health.Status == "healthy", health.Status, map[string]interface{}{
-		"message": health.Message,
-		"details": health.Details,
+		"message":   health.Message,
+		"details":   health.Details,
 		"timestamp": health.Timestamp,
 	})
 	h.sendJSONResponse(w, http.StatusOK, response)
@@ -412,10 +412,10 @@ func (h *SearchHandler) handleDetailedHealthCheck(w http.ResponseWriter, r *http
 	}
 
 	response := h.formatter.FormatHealthResponse(health.Status == "healthy", health.Status, map[string]interface{}{
-		"message": health.Message,
-		"details": health.Details,
+		"message":   health.Message,
+		"details":   health.Details,
 		"timestamp": health.Timestamp,
-		"checks": health.Checks,
+		"checks":    health.Checks,
 	})
 	h.sendJSONResponse(w, http.StatusOK, response)
 }
@@ -431,16 +431,18 @@ func (h *SearchHandler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		metricType = "system"
 	}
 
-    mvals, err := h.service.GetMetrics(ctx, metricType, "", "")
+	mvals, err := h.service.GetMetrics(ctx, metricType, "", "")
 	if err != nil {
 		h.handleError(w, r, err, queryID, "METRICS_ERROR")
 		return
 	}
 
-    // Convert to map[string]interface{}
-    imap := make(map[string]interface{}, len(mvals))
-    for k, v := range mvals { imap[k] = v }
-    response := h.formatter.FormatMetricsResponse(imap)
+	// Convert to map[string]interface{}
+	imap := make(map[string]interface{}, len(mvals))
+	for k, v := range mvals {
+		imap[k] = v
+	}
+	response := h.formatter.FormatMetricsResponse(imap)
 	h.sendJSONResponse(w, http.StatusOK, response)
 }
 
@@ -483,21 +485,21 @@ func (h *SearchHandler) handleUpdateConfig(w http.ResponseWriter, r *http.Reques
 // Request types
 
 type SearchRequest struct {
-	Vector   []float64         `json:"vector"`
-	VectorID string            `json:"vector_id,omitempty"`
-	K        int               `json:"k,omitempty"`
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Vector         []float64         `json:"vector"`
+	VectorID       string            `json:"vector_id,omitempty"`
+	K              int               `json:"k,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
 	MetadataFilter map[string]string `json:"metadata_filter,omitempty"`
 }
 
 type SimilaritySearchRequest struct {
-	Vector           []float64         `json:"vector"`
-	VectorID         string            `json:"vector_id,omitempty"`
-	K                int               `json:"k,omitempty"`
-	Metadata         map[string]string `json:"metadata,omitempty"`
-	MetadataFilter   map[string]string `json:"metadata_filter,omitempty"`
-	Filters          []MetadataFilter  `json:"filters,omitempty"`
-	DistanceThreshold float64          `json:"distance_threshold,omitempty"`
+	Vector            []float64         `json:"vector"`
+	VectorID          string            `json:"vector_id,omitempty"`
+	K                 int               `json:"k,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	MetadataFilter    map[string]string `json:"metadata_filter,omitempty"`
+	Filters           []MetadataFilter  `json:"filters,omitempty"`
+	DistanceThreshold float64           `json:"distance_threshold,omitempty"`
 }
 
 type MetadataFilter struct {
@@ -508,9 +510,9 @@ type MetadataFilter struct {
 }
 
 type BatchSearchRequest struct {
-	Queries          []SearchRequest `json:"queries"`
-	MetadataFilter   map[string]string `json:"metadata_filter,omitempty"`
-	K                int               `json:"k,omitempty"`
+	Queries        []SearchRequest   `json:"queries"`
+	MetadataFilter map[string]string `json:"metadata_filter,omitempty"`
+	K              int               `json:"k,omitempty"`
 }
 
 type MultiClusterSearchRequest struct {
@@ -618,14 +620,14 @@ func (h *SearchHandler) filterByDistance(results []*types.SearchResult, threshol
 
 func (h *SearchHandler) handleError(w http.ResponseWriter, r *http.Request, err error, queryID string, code string) {
 	h.logger.Error("Request failed", zap.String("query_id", queryID), zap.Error(err))
-	
+
 	errorResponse := h.formatter.FormatErrorResponse(err, queryID, code, nil)
 	h.sendJSONResponse(w, h.getHTTPStatusCode(code), errorResponse)
 }
 
 func (h *SearchHandler) handleValidationError(w http.ResponseWriter, r *http.Request, err error, queryID string) {
 	h.logger.Warn("Validation failed", zap.String("query_id", queryID), zap.Error(err))
-	
+
 	// Convert error to validation errors
 	validationErrors := []response.ValidationError{
 		{
@@ -633,7 +635,7 @@ func (h *SearchHandler) handleValidationError(w http.ResponseWriter, r *http.Req
 			Message: err.Error(),
 		},
 	}
-	
+
 	errorResponse := h.formatter.FormatValidationErrorResponse(validationErrors, queryID)
 	h.sendJSONResponse(w, http.StatusBadRequest, errorResponse)
 }
@@ -679,7 +681,7 @@ func (h *SearchHandler) recordMetrics(operation string, duration time.Duration, 
 }
 
 func generateQueryID() string {
-    return fmt.Sprintf("query_%d", time.Now().UnixNano())
+	return fmt.Sprintf("query_%d", time.Now().UnixNano())
 }
 
 func getStatusLabel(err error) string {
@@ -691,16 +693,24 @@ func getStatusLabel(err error) string {
 
 // toFloat32 converts []float64 to []float32 safely
 func toFloat32(in []float64) []float32 {
-    if len(in) == 0 { return nil }
-    out := make([]float32, len(in))
-    for i, v := range in { out[i] = float32(v) }
-    return out
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]float32, len(in))
+	for i, v := range in {
+		out[i] = float32(v)
+	}
+	return out
 }
 
 // toMetadata converts map[string]string to map[string]interface{}
 func toMetadata(in map[string]string) map[string]interface{} {
-    if in == nil { return nil }
-    out := make(map[string]interface{}, len(in))
-    for k, v := range in { out[k] = v }
-    return out
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/search/auth/middleware.go
+++ b/internal/search/auth/middleware.go
@@ -1,16 +1,16 @@
 package auth
 
 import (
-    "context"
-    "crypto/subtle"
-    "encoding/base64"
-    "fmt"
-    "net/http"
-    "strings"
-    "time"
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
-    "vexdb/internal/search/config"
 	"go.uber.org/zap"
+	"vxdb/internal/search/config"
 )
 
 // Middleware provides authentication middleware for the search service
@@ -217,9 +217,9 @@ func (m *Middleware) sendUnauthorized(w http.ResponseWriter, message string) {
 	w.Header().Set("WWW-Authenticate", m.getAuthenticateHeader())
 	w.WriteHeader(http.StatusUnauthorized)
 
-    // Simple JSON encoding - in production, use proper JSON marshaling
-    jsonResponse := fmt.Sprintf(`{"success":false,"error":"unauthorized","message":"%s","timestamp":"%s"}`,
-        message, time.Now().Format(time.RFC3339))
+	// Simple JSON encoding - in production, use proper JSON marshaling
+	jsonResponse := fmt.Sprintf(`{"success":false,"error":"unauthorized","message":"%s","timestamp":"%s"}`,
+		message, time.Now().Format(time.RFC3339))
 
 	w.Write([]byte(jsonResponse))
 }
@@ -228,13 +228,13 @@ func (m *Middleware) sendUnauthorized(w http.ResponseWriter, message string) {
 func (m *Middleware) getAuthenticateHeader() string {
 	switch m.config.Type {
 	case "basic":
-		return `Basic realm="VexDB Search Service"`
+		return `Basic realm="VxDB Search Service"`
 	case "bearer":
-		return `Bearer realm="VexDB Search Service"`
+		return `Bearer realm="VxDB Search Service"`
 	case "api_key":
-		return `ApiKey realm="VexDB Search Service"`
+		return `ApiKey realm="VxDB Search Service"`
 	default:
-		return `Basic realm="VexDB Search Service"`
+		return `Basic realm="VxDB Search Service"`
 	}
 }
 
@@ -248,7 +248,7 @@ type RateLimitMiddleware struct {
 // NewRateLimitMiddleware creates a new rate limiting middleware
 func NewRateLimitMiddleware(cfg *config.RateLimitConfig, logger *zap.Logger) *RateLimitMiddleware {
 	rateLimit := NewRateLimiter(cfg.RequestsPerSecond, cfg.BurstSize, cfg.CleanupInterval)
-	
+
 	return &RateLimitMiddleware{
 		config:    cfg,
 		logger:    logger,
@@ -267,7 +267,7 @@ func (m *RateLimitMiddleware) RateLimitMiddleware(next http.Handler) http.Handle
 
 		// Get identifier for rate limiting
 		identifier := m.getIdentifier(r)
-		
+
 		// Check rate limit
 		if !m.rateLimit.Allow(identifier) {
 			m.logger.Warn("Rate limit exceeded", zap.String("identifier", identifier))
@@ -321,9 +321,9 @@ func (m *RateLimitMiddleware) sendRateLimitExceeded(w http.ResponseWriter) {
 	w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", time.Now().Add(m.config.CleanupInterval).Unix()))
 	w.WriteHeader(http.StatusTooManyRequests)
 
-    // Simple JSON encoding - in production, use proper JSON marshaling
-    jsonResponse := fmt.Sprintf(`{"success":false,"error":"rate_limit_exceeded","message":"Rate limit exceeded. Please try again later.","timestamp":"%s"}`,
-        time.Now().Format(time.RFC3339))
+	// Simple JSON encoding - in production, use proper JSON marshaling
+	jsonResponse := fmt.Sprintf(`{"success":false,"error":"rate_limit_exceeded","message":"Rate limit exceeded. Please try again later.","timestamp":"%s"}`,
+		time.Now().Format(time.RFC3339))
 
 	w.Write([]byte(jsonResponse))
 }
@@ -377,7 +377,7 @@ func (m *CORSMiddleware) CORSMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", m.getAllowedOrigin(r.Header.Get("Origin")))
 		w.Header().Set("Access-Control-Allow-Methods", strings.Join(m.config.AllowedMethods, ", "))
 		w.Header().Set("Access-Control-Allow-Headers", strings.Join(m.config.AllowedHeaders, ", "))
-		
+
 		if m.config.AllowCredentials {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 		}

--- a/internal/search/auth/ratelimit.go
+++ b/internal/search/auth/ratelimit.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
-    "context"
-    "sync"
-    "time"
+	"context"
+	"sync"
+	"time"
 )
 
 // RateLimiter implements a token bucket rate limiter
@@ -154,14 +154,14 @@ func (rl *RateLimiter) cleanup() {
 	for range ticker.C {
 		rl.mu.Lock()
 		now := time.Now()
-		
+
 		// Remove buckets that haven't been accessed in a long time
 		for identifier, b := range rl.buckets {
 			if now.Sub(b.lastCheck) > rl.cleanupInterval*2 {
 				delete(rl.buckets, identifier)
 			}
 		}
-		
+
 		rl.mu.Unlock()
 	}
 }
@@ -334,14 +334,14 @@ func (rl *SlidingWindowRateLimiter) cleanup() {
 				delete(rl.requests, identifier)
 			}
 		}
-		
+
 		rl.mu.Unlock()
 	}
 }
 
 // SlidingWindowStats represents sliding window rate limiter statistics
 type SlidingWindowStats struct {
-	TotalIdentifiers int                                      `json:"total_identifiers"`
+	TotalIdentifiers int                                     `json:"total_identifiers"`
 	Identifiers      map[string]SlidingWindowIdentifierStats `json:"identifiers"`
 }
 

--- a/internal/search/benchmark/benchmark_test.go
+++ b/internal/search/benchmark/benchmark_test.go
@@ -1,22 +1,22 @@
 package benchmark
 
 import (
-       "fmt"
-       "math"
-       "math/rand"
-       "testing"
-       "time"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
 
-       "vexdb/internal/search/config"
-       "vexdb/internal/search/response"
-       "vexdb/internal/search/validation"
-       "vexdb/internal/types"
+	"vxdb/internal/search/config"
+	"vxdb/internal/search/response"
+	"vxdb/internal/search/validation"
+	"vxdb/internal/types"
 )
 
 // BenchmarkSearchValidation benchmarks the search validation performance
 func BenchmarkSearchValidation(b *testing.B) {
 	validator := validation.NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	// Create test vectors of different dimensions
 	testVectors := map[string]*types.Vector{
 		"small":  createTestVector(10),
@@ -24,7 +24,7 @@ func BenchmarkSearchValidation(b *testing.B) {
 		"large":  createTestVector(500),
 		"xlarge": createTestVector(1000),
 	}
-	
+
 	for name, vector := range testVectors {
 		b.Run(fmt.Sprintf("VectorDimension_%s", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -40,16 +40,16 @@ func BenchmarkSearchValidation(b *testing.B) {
 // BenchmarkSearchValidationWithMetadata benchmarks validation with metadata filters
 func BenchmarkSearchValidationWithMetadata(b *testing.B) {
 	validator := validation.NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	query := createTestVector(100)
-	
+
 	// Create metadata filters of different complexities
 	filters := map[string]*types.MetadataFilter{
-		"simple": createSimpleMetadataFilter(),
-		"medium": createMediumMetadataFilter(),
+		"simple":  createSimpleMetadataFilter(),
+		"medium":  createMediumMetadataFilter(),
 		"complex": createComplexMetadataFilter(),
 	}
-	
+
 	for name, filter := range filters {
 		b.Run(fmt.Sprintf("MetadataFilter_%s", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -65,14 +65,14 @@ func BenchmarkSearchValidationWithMetadata(b *testing.B) {
 // BenchmarkResponseFormatting benchmarks response formatting performance
 func BenchmarkResponseFormatting(b *testing.B) {
 	formatter := response.NewFormatter(response.DefaultResponseConfig())
-	
+
 	// Create result sets of different sizes
 	resultSets := map[string][]*types.SearchResult{
 		"small":  createSearchResults(10),
 		"medium": createSearchResults(100),
 		"large":  createSearchResults(1000),
 	}
-	
+
 	query := createTestVector(100)
 	stats := &response.SearchStats{
 		TotalResults:    1000,
@@ -84,14 +84,14 @@ func BenchmarkResponseFormatting(b *testing.B) {
 		NodesQueried:    3,
 		ClustersQueried: 5,
 	}
-	
+
 	for name, results := range resultSets {
 		b.Run(fmt.Sprintf("ResultSet_%s", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-                               resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
-                               if resp == nil {
-                                       b.Fatal("Expected response to be created")
-                               }
+				resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
+				if resp == nil {
+					b.Fatal("Expected response to be created")
+				}
 			}
 		})
 	}
@@ -125,7 +125,7 @@ func BenchmarkResponseFormattingWithMetadata(b *testing.B) {
 			PrettyPrint:        true,
 		},
 	}
-	
+
 	results := createSearchResults(100)
 	query := createTestVector(100)
 	stats := &response.SearchStats{
@@ -133,15 +133,15 @@ func BenchmarkResponseFormattingWithMetadata(b *testing.B) {
 		ReturnedResults: 100,
 		ExecutionTime:   50 * time.Millisecond,
 	}
-	
+
 	for name, config := range configs {
 		b.Run(fmt.Sprintf("Config_%s", name), func(b *testing.B) {
 			formatter := response.NewFormatter(config)
 			for i := 0; i < b.N; i++ {
-                               resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
-                               if resp == nil {
-                                       b.Fatal("Expected response to be created")
-                               }
+				resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
+				if resp == nil {
+					b.Fatal("Expected response to be created")
+				}
 			}
 		})
 	}
@@ -150,10 +150,10 @@ func BenchmarkResponseFormattingWithMetadata(b *testing.B) {
 // BenchmarkBatchResponseFormatting benchmarks batch response formatting
 func BenchmarkBatchResponseFormatting(b *testing.B) {
 	formatter := response.NewFormatter(response.DefaultResponseConfig())
-	
+
 	// Create batch results of different sizes
 	batchSizes := []int{10, 50, 100}
-	
+
 	for _, batchSize := range batchSizes {
 		b.Run(fmt.Sprintf("BatchSize_%d", batchSize), func(b *testing.B) {
 			// Create batch results
@@ -161,7 +161,7 @@ func BenchmarkBatchResponseFormatting(b *testing.B) {
 			queries := make([]*types.Vector, batchSize)
 			queryIDs := make([]string, batchSize)
 			stats := make([]*response.SearchStats, batchSize)
-			
+
 			for i := 0; i < batchSize; i++ {
 				allResults[i] = createSearchResults(10)
 				queries[i] = createTestVector(100)
@@ -172,12 +172,12 @@ func BenchmarkBatchResponseFormatting(b *testing.B) {
 					ExecutionTime:   50 * time.Millisecond,
 				}
 			}
-			
+
 			for i := 0; i < b.N; i++ {
-                               resp := formatter.FormatBatchResponse(allResults, queries, 10, queryIDs, stats)
-                               if resp == nil {
-                                       b.Fatal("Expected batch response to be created")
-                               }
+				resp := formatter.FormatBatchResponse(allResults, queries, 10, queryIDs, stats)
+				if resp == nil {
+					b.Fatal("Expected batch response to be created")
+				}
 			}
 		})
 	}
@@ -186,7 +186,7 @@ func BenchmarkBatchResponseFormatting(b *testing.B) {
 // BenchmarkJSONSerialization benchmarks JSON serialization performance
 func BenchmarkJSONSerialization(b *testing.B) {
 	formatter := response.NewFormatter(&response.ResponseConfig{PrettyPrint: false})
-	
+
 	results := createSearchResults(100)
 	query := createTestVector(100)
 	stats := &response.SearchStats{
@@ -194,12 +194,12 @@ func BenchmarkJSONSerialization(b *testing.B) {
 		ReturnedResults: 100,
 		ExecutionTime:   50 * time.Millisecond,
 	}
-	
-       resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
-	
+
+	resp := formatter.FormatSearchResponse(results, query, 100, "benchmark-query", stats)
+
 	b.Run("CompactJSON", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-               jsonData, err := formatter.ToJSON(resp)
+			jsonData, err := formatter.ToJSON(resp)
 			if err != nil {
 				b.Fatalf("JSON serialization failed: %v", err)
 			}
@@ -208,12 +208,12 @@ func BenchmarkJSONSerialization(b *testing.B) {
 			}
 		}
 	})
-	
-       prettyFormatter := response.NewFormatter(&response.ResponseConfig{PrettyPrint: true})
-	
+
+	prettyFormatter := response.NewFormatter(&response.ResponseConfig{PrettyPrint: true})
+
 	b.Run("PrettyJSON", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-               jsonData, err := prettyFormatter.ToJSON(resp)
+			jsonData, err := prettyFormatter.ToJSON(resp)
 			if err != nil {
 				b.Fatalf("JSON serialization failed: %v", err)
 			}
@@ -226,36 +226,36 @@ func BenchmarkJSONSerialization(b *testing.B) {
 
 // BenchmarkConfigurationValidation benchmarks configuration validation performance
 func BenchmarkConfigurationValidation(b *testing.B) {
-       cfg := config.DefaultSearchServiceConfig()
-	
-       b.Run("DefaultConfig", func(b *testing.B) {
-               for i := 0; i < b.N; i++ {
-                       err := cfg.Validate()
+	cfg := config.DefaultSearchServiceConfig()
+
+	b.Run("DefaultConfig", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			err := cfg.Validate()
 			if err != nil {
 				b.Fatalf("Configuration validation failed: %v", err)
 			}
 		}
 	})
-	
+
 	// Test with various modifications
-       invalidConfigs := map[string]*config.SearchServiceConfig{
-               "invalid_host": func() *config.SearchServiceConfig {
-                       c := *cfg
+	invalidConfigs := map[string]*config.SearchServiceConfig{
+		"invalid_host": func() *config.SearchServiceConfig {
+			c := *cfg
 			c.Server.Host = ""
 			return &c
 		}(),
-               "invalid_port": func() *config.SearchServiceConfig {
-                       c := *cfg
+		"invalid_port": func() *config.SearchServiceConfig {
+			c := *cfg
 			c.Server.Port = 0
 			return &c
 		}(),
-               "invalid_engine": func() *config.SearchServiceConfig {
-                       c := *cfg
+		"invalid_engine": func() *config.SearchServiceConfig {
+			c := *cfg
 			c.Engine.MaxResults = -1
 			return &c
 		}(),
 	}
-	
+
 	for name, invalidConfig := range invalidConfigs {
 		b.Run(fmt.Sprintf("InvalidConfig_%s", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -271,7 +271,7 @@ func BenchmarkConfigurationValidation(b *testing.B) {
 // BenchmarkVectorGeneration benchmarks vector generation performance
 func BenchmarkVectorGeneration(b *testing.B) {
 	dimensions := []int{10, 50, 100, 500, 1000}
-	
+
 	for _, dim := range dimensions {
 		b.Run(fmt.Sprintf("Dimension_%d", dim), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -290,12 +290,12 @@ func BenchmarkVectorGeneration(b *testing.B) {
 // BenchmarkDistanceCalculation benchmarks distance calculation performance
 func BenchmarkDistanceCalculation(b *testing.B) {
 	dimensions := []int{10, 50, 100, 500, 1000}
-	
+
 	for _, dim := range dimensions {
 		b.Run(fmt.Sprintf("Dimension_%d", dim), func(b *testing.B) {
 			query := createTestVector(dim)
 			target := createTestVector(dim)
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				distance := calculateEuclideanDistance(query.Data, target.Data)
@@ -314,7 +314,7 @@ func createTestVector(dimension int) *types.Vector {
 	for i := 0; i < dimension; i++ {
 		data[i] = rand.Float32()
 	}
-	
+
 	return &types.Vector{
 		ID:   fmt.Sprintf("test-vector-%d", dimension),
 		Data: data,
@@ -328,7 +328,7 @@ func createTestVector(dimension int) *types.Vector {
 
 func createSearchResults(count int) []*types.SearchResult {
 	results := make([]*types.SearchResult, count)
-	
+
 	for i := 0; i < count; i++ {
 		vector := createTestVector(100)
 		results[i] = &types.SearchResult{
@@ -336,7 +336,7 @@ func createSearchResults(count int) []*types.SearchResult {
 			Distance: float64(i) * 0.1,
 		}
 	}
-	
+
 	return results
 }
 
@@ -405,12 +405,12 @@ func calculateEuclideanDistance(a, b []float32) float64 {
 	if len(a) != len(b) {
 		return -1 // Error case
 	}
-	
+
 	sum := 0.0
 	for i := 0; i < len(a); i++ {
 		diff := float64(a[i]) - float64(b[i])
 		sum += diff * diff
 	}
-	
+
 	return math.Sqrt(sum)
 }

--- a/internal/search/config/config.go
+++ b/internal/search/config/config.go
@@ -9,80 +9,80 @@ import (
 type SearchServiceConfig struct {
 	// Server configuration
 	Server ServerConfig `yaml:"server" json:"server"`
-	
+
 	// Search engine configuration
 	Engine EngineConfig `yaml:"engine" json:"engine"`
-	
+
 	// API configuration
 	API APIConfig `yaml:"api" json:"api"`
-	
+
 	// Authentication configuration
 	Auth AuthConfig `yaml:"auth" json:"auth"`
-	
+
 	// Rate limiting configuration
 	RateLimit RateLimitConfig `yaml:"rate_limit" json:"rate_limit"`
-	
+
 	// Metrics configuration
 	Metrics MetricsConfig `yaml:"metrics" json:"metrics"`
-	
+
 	// Logging configuration
 	Logging LoggingConfig `yaml:"logging" json:"logging"`
-	
+
 	// Health check configuration
 	Health HealthConfig `yaml:"health" json:"health"`
 }
 
 // ServerConfig represents server-specific configuration
 type ServerConfig struct {
-	Host         string        `yaml:"host" json:"host"`
-	Port         int           `yaml:"port" json:"port"`
-	ReadTimeout  time.Duration `yaml:"read_timeout" json:"read_timeout"`
-	WriteTimeout time.Duration `yaml:"write_timeout" json:"write_timeout"`
-	IdleTimeout  time.Duration `yaml:"idle_timeout" json:"idle_timeout"`
-	MaxHeaderBytes int         `yaml:"max_header_bytes" json:"max_header_bytes"`
+	Host           string        `yaml:"host" json:"host"`
+	Port           int           `yaml:"port" json:"port"`
+	ReadTimeout    time.Duration `yaml:"read_timeout" json:"read_timeout"`
+	WriteTimeout   time.Duration `yaml:"write_timeout" json:"write_timeout"`
+	IdleTimeout    time.Duration `yaml:"idle_timeout" json:"idle_timeout"`
+	MaxHeaderBytes int           `yaml:"max_header_bytes" json:"max_header_bytes"`
 }
 
 // EngineConfig represents search engine configuration
 type EngineConfig struct {
-	MaxResults      int     `yaml:"max_results" json:"max_results"`
-	DefaultK        int     `yaml:"default_k" json:"default_k"`
-	DistanceType    string  `yaml:"distance_type" json:"distance_type"`
-	EnableCache     bool    `yaml:"enable_cache" json:"enable_cache"`
-	CacheSize       int     `yaml:"cache_size" json:"cache_size"`
-	CacheTTL        time.Duration `yaml:"cache_ttl" json:"cache_ttl"`
-	ParallelSearch  bool    `yaml:"parallel_search" json:"parallel_search"`
-	MaxWorkers      int     `yaml:"max_workers" json:"max_workers"`
+	MaxResults     int           `yaml:"max_results" json:"max_results"`
+	DefaultK       int           `yaml:"default_k" json:"default_k"`
+	DistanceType   string        `yaml:"distance_type" json:"distance_type"`
+	EnableCache    bool          `yaml:"enable_cache" json:"enable_cache"`
+	CacheSize      int           `yaml:"cache_size" json:"cache_size"`
+	CacheTTL       time.Duration `yaml:"cache_ttl" json:"cache_ttl"`
+	ParallelSearch bool          `yaml:"parallel_search" json:"parallel_search"`
+	MaxWorkers     int           `yaml:"max_workers" json:"max_workers"`
 }
 
 // APIConfig represents API-specific configuration
 type APIConfig struct {
 	// HTTP configuration
 	HTTP HTTPConfig `yaml:"http" json:"http"`
-	
+
 	// gRPC configuration
 	GRPC GRPCConfig `yaml:"grpc" json:"grpc"`
-	
+
 	// Response formatting
 	Response ResponseConfig `yaml:"response" json:"response"`
 }
 
 // HTTPConfig represents HTTP API configuration
 type HTTPConfig struct {
-	Enabled            bool          `yaml:"enabled" json:"enabled"`
-	BasePath           string        `yaml:"base_path" json:"base_path"`
-	CORS               CORSConfig    `yaml:"cors" json:"cors"`
-	RequestSizeLimit   int64         `yaml:"request_size_limit" json:"request_size_limit"`
-	EnableCompression  bool          `yaml:"enable_compression" json:"enable_compression"`
-	CompressionLevel   int           `yaml:"compression_level" json:"compression_level"`
-	TLS                *TLSConfig    `yaml:"tls" json:"tls"`
+	Enabled           bool       `yaml:"enabled" json:"enabled"`
+	BasePath          string     `yaml:"base_path" json:"base_path"`
+	CORS              CORSConfig `yaml:"cors" json:"cors"`
+	RequestSizeLimit  int64      `yaml:"request_size_limit" json:"request_size_limit"`
+	EnableCompression bool       `yaml:"enable_compression" json:"enable_compression"`
+	CompressionLevel  int        `yaml:"compression_level" json:"compression_level"`
+	TLS               *TLSConfig `yaml:"tls" json:"tls"`
 }
 
 // GRPCConfig represents gRPC API configuration
 type GRPCConfig struct {
-	Enabled            bool          `yaml:"enabled" json:"enabled"`
-	MaxMessageSize     int           `yaml:"max_message_size" json:"max_message_size"`
-	MaxConcurrentStreams int         `yaml:"max_concurrent_streams" json:"max_concurrent_streams"`
-	Keepalive          KeepaliveConfig `yaml:"keepalive" json:"keepalive"`
+	Enabled              bool            `yaml:"enabled" json:"enabled"`
+	MaxMessageSize       int             `yaml:"max_message_size" json:"max_message_size"`
+	MaxConcurrentStreams int             `yaml:"max_concurrent_streams" json:"max_concurrent_streams"`
+	Keepalive            KeepaliveConfig `yaml:"keepalive" json:"keepalive"`
 }
 
 // CORSConfig represents CORS configuration
@@ -113,12 +113,12 @@ type ResponseConfig struct {
 
 // AuthConfig represents authentication configuration
 type AuthConfig struct {
-	Enabled      bool         `yaml:"enabled" json:"enabled"`
-	Type         string       `yaml:"type" json:"type"` // "none", "basic", "bearer", "api_key"
-	APIKeys      []string     `yaml:"api_keys" json:"api_keys"`
-	BasicAuth    BasicAuthConfig `yaml:"basic_auth" json:"basic_auth"`
-	BearerAuth   BearerAuthConfig `yaml:"bearer_auth" json:"bearer_auth"`
-	RateLimitBy  string       `yaml:"rate_limit_by" json:"rate_limit_by"` // "ip", "user", "api_key"
+	Enabled     bool             `yaml:"enabled" json:"enabled"`
+	Type        string           `yaml:"type" json:"type"` // "none", "basic", "bearer", "api_key"
+	APIKeys     []string         `yaml:"api_keys" json:"api_keys"`
+	BasicAuth   BasicAuthConfig  `yaml:"basic_auth" json:"basic_auth"`
+	BearerAuth  BearerAuthConfig `yaml:"bearer_auth" json:"bearer_auth"`
+	RateLimitBy string           `yaml:"rate_limit_by" json:"rate_limit_by"` // "ip", "user", "api_key"
 }
 
 // BasicAuthConfig represents basic authentication configuration
@@ -134,13 +134,13 @@ type BearerAuthConfig struct {
 
 // RateLimitConfig represents rate limiting configuration
 type RateLimitConfig struct {
-	Enabled      bool    `yaml:"enabled" json:"enabled"`
-	RequestsPerSecond float64 `yaml:"requests_per_second" json:"requests_per_second"`
-	BurstSize      int     `yaml:"burst_size" json:"burst_size"`
-	CleanupInterval time.Duration `yaml:"cleanup_interval" json:"cleanup_interval"`
-	ByIP           bool    `yaml:"by_ip" json:"by_ip"`
-	ByUser         bool    `yaml:"by_user" json:"by_user"`
-	ByAPIKey       bool    `yaml:"by_api_key" json:"by_api_key"`
+	Enabled           bool          `yaml:"enabled" json:"enabled"`
+	RequestsPerSecond float64       `yaml:"requests_per_second" json:"requests_per_second"`
+	BurstSize         int           `yaml:"burst_size" json:"burst_size"`
+	CleanupInterval   time.Duration `yaml:"cleanup_interval" json:"cleanup_interval"`
+	ByIP              bool          `yaml:"by_ip" json:"by_ip"`
+	ByUser            bool          `yaml:"by_user" json:"by_user"`
+	ByAPIKey          bool          `yaml:"by_api_key" json:"by_api_key"`
 }
 
 // MetricsConfig represents metrics configuration
@@ -177,11 +177,11 @@ type TLSConfig struct {
 func DefaultSearchServiceConfig() *SearchServiceConfig {
 	return &SearchServiceConfig{
 		Server: ServerConfig{
-			Host:         "0.0.0.0",
-			Port:         8080,
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 30 * time.Second,
-			IdleTimeout:  120 * time.Second,
+			Host:           "0.0.0.0",
+			Port:           8080,
+			ReadTimeout:    30 * time.Second,
+			WriteTimeout:   30 * time.Second,
+			IdleTimeout:    120 * time.Second,
 			MaxHeaderBytes: 1048576, // 1MB
 		},
 		Engine: EngineConfig{
@@ -196,11 +196,11 @@ func DefaultSearchServiceConfig() *SearchServiceConfig {
 		},
 		API: APIConfig{
 			HTTP: HTTPConfig{
-				Enabled:          true,
-				BasePath:         "/api/v1",
-				RequestSizeLimit: 10485760, // 10MB
+				Enabled:           true,
+				BasePath:          "/api/v1",
+				RequestSizeLimit:  10485760, // 10MB
 				EnableCompression: true,
-				CompressionLevel: 6,
+				CompressionLevel:  6,
 				CORS: CORSConfig{
 					Enabled:        true,
 					AllowedOrigins: []string{"*"},
@@ -232,15 +232,15 @@ func DefaultSearchServiceConfig() *SearchServiceConfig {
 			RateLimitBy: "ip",
 		},
 		RateLimit: RateLimitConfig{
-			Enabled:         false,
+			Enabled:           false,
 			RequestsPerSecond: 100.0,
-			BurstSize:       200,
-			CleanupInterval: 1 * time.Minute,
-			ByIP:            true,
+			BurstSize:         200,
+			CleanupInterval:   1 * time.Minute,
+			ByIP:              true,
 		},
 		Metrics: MetricsConfig{
 			Enabled:   true,
-			Namespace: "vexdb",
+			Namespace: "vxdb",
 			Subsystem: "search",
 			Path:      "/metrics",
 		},

--- a/internal/search/config/config_test.go
+++ b/internal/search/config/config_test.go
@@ -7,99 +7,99 @@ import (
 
 func TestDefaultSearchServiceConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	if config == nil {
 		t.Fatal("Expected config to be created, got nil")
 	}
-	
+
 	// Test server configuration
 	if config.Server.Host != "0.0.0.0" {
 		t.Errorf("Expected Server.Host to be '0.0.0.0', got '%s'", config.Server.Host)
 	}
-	
+
 	if config.Server.Port != 8080 {
 		t.Errorf("Expected Server.Port to be 8080, got %d", config.Server.Port)
 	}
-	
+
 	if config.Server.ReadTimeout != 30*time.Second {
 		t.Errorf("Expected Server.ReadTimeout to be 30s, got %v", config.Server.ReadTimeout)
 	}
-	
+
 	// Test engine configuration
 	if config.Engine.MaxResults != 1000 {
 		t.Errorf("Expected Engine.MaxResults to be 1000, got %d", config.Engine.MaxResults)
 	}
-	
+
 	if config.Engine.DefaultK != 10 {
 		t.Errorf("Expected Engine.DefaultK to be 10, got %d", config.Engine.DefaultK)
 	}
-	
+
 	if config.Engine.DistanceType != "euclidean" {
 		t.Errorf("Expected Engine.DistanceType to be 'euclidean', got '%s'", config.Engine.DistanceType)
 	}
-	
+
 	if !config.Engine.EnableCache {
 		t.Error("Expected Engine.EnableCache to be true")
 	}
-	
+
 	if config.Engine.CacheSize != 1000 {
 		t.Errorf("Expected Engine.CacheSize to be 1000, got %d", config.Engine.CacheSize)
 	}
-	
+
 	// Test API configuration
 	if !config.API.HTTP.Enabled {
 		t.Error("Expected API.HTTP.Enabled to be true")
 	}
-	
+
 	if config.API.HTTP.BasePath != "/api/v1" {
 		t.Errorf("Expected API.HTTP.BasePath to be '/api/v1', got '%s'", config.API.HTTP.BasePath)
 	}
-	
+
 	if !config.API.GRPC.Enabled {
 		t.Error("Expected API.GRPC.Enabled to be true")
 	}
-	
+
 	// Test authentication configuration
 	if config.Auth.Enabled {
 		t.Error("Expected Auth.Enabled to be false by default")
 	}
-	
+
 	if config.Auth.Type != "none" {
 		t.Errorf("Expected Auth.Type to be 'none', got '%s'", config.Auth.Type)
 	}
-	
+
 	// Test rate limiting configuration
 	if config.RateLimit.Enabled {
 		t.Error("Expected RateLimit.Enabled to be false by default")
 	}
-	
+
 	if config.RateLimit.RequestsPerSecond != 100.0 {
 		t.Errorf("Expected RateLimit.RequestsPerSecond to be 100.0, got %f", config.RateLimit.RequestsPerSecond)
 	}
-	
+
 	// Test metrics configuration
 	if !config.Metrics.Enabled {
 		t.Error("Expected Metrics.Enabled to be true")
 	}
-	
-	if config.Metrics.Namespace != "vexdb" {
-		t.Errorf("Expected Metrics.Namespace to be 'vexdb', got '%s'", config.Metrics.Namespace)
+
+	if config.Metrics.Namespace != "vxdb" {
+		t.Errorf("Expected Metrics.Namespace to be 'vxdb', got '%s'", config.Metrics.Namespace)
 	}
-	
+
 	// Test logging configuration
 	if config.Logging.Level != "info" {
 		t.Errorf("Expected Logging.Level to be 'info', got '%s'", config.Logging.Level)
 	}
-	
+
 	if config.Logging.Format != "json" {
 		t.Errorf("Expected Logging.Format to be 'json', got '%s'", config.Logging.Format)
 	}
-	
+
 	// Test health configuration
 	if !config.Health.Enabled {
 		t.Error("Expected Health.Enabled to be true")
 	}
-	
+
 	if config.Health.CheckInterval != 30*time.Second {
 		t.Errorf("Expected Health.CheckInterval to be 30s, got %v", config.Health.CheckInterval)
 	}
@@ -107,9 +107,9 @@ func TestDefaultSearchServiceConfig(t *testing.T) {
 
 func TestSearchServiceConfig_Validate_ValidConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	err := config.Validate()
-	
+
 	if err != nil {
 		t.Errorf("Expected no validation error for default config, got: %v", err)
 	}
@@ -118,13 +118,13 @@ func TestSearchServiceConfig_Validate_ValidConfig(t *testing.T) {
 func TestSearchServiceConfig_Validate_InvalidServerHost(t *testing.T) {
 	config := DefaultSearchServiceConfig()
 	config.Server.Host = ""
-	
+
 	err := config.Validate()
-	
+
 	if err == nil {
 		t.Error("Expected validation error for empty server host, got nil")
 	}
-	
+
 	if err.Error() != "server host is required" {
 		t.Errorf("Expected 'server host is required', got: %v", err)
 	}
@@ -132,14 +132,14 @@ func TestSearchServiceConfig_Validate_InvalidServerHost(t *testing.T) {
 
 func TestSearchServiceConfig_Validate_InvalidServerPort(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	// Test port too low
 	config.Server.Port = 0
 	err := config.Validate()
 	if err == nil {
 		t.Error("Expected validation error for port 0, got nil")
 	}
-	
+
 	// Test port too high
 	config.Server.Port = 70000
 	err = config.Validate()
@@ -150,14 +150,14 @@ func TestSearchServiceConfig_Validate_InvalidServerPort(t *testing.T) {
 
 func TestSearchServiceConfig_Validate_InvalidServerTimeouts(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	// Test negative read timeout
 	config.Server.ReadTimeout = -1 * time.Second
 	err := config.Validate()
 	if err == nil {
 		t.Error("Expected validation error for negative read timeout, got nil")
 	}
-	
+
 	// Reset and test zero read timeout
 	config = DefaultSearchServiceConfig()
 	config.Server.ReadTimeout = 0
@@ -165,7 +165,7 @@ func TestSearchServiceConfig_Validate_InvalidServerTimeouts(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for zero read timeout, got nil")
 	}
-	
+
 	// Test negative write timeout
 	config = DefaultSearchServiceConfig()
 	config.Server.WriteTimeout = -1 * time.Second
@@ -177,14 +177,14 @@ func TestSearchServiceConfig_Validate_InvalidServerTimeouts(t *testing.T) {
 
 func TestSearchServiceConfig_Validate_InvalidEngineConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	// Test negative max results
 	config.Engine.MaxResults = -1
 	err := config.Validate()
 	if err == nil {
 		t.Error("Expected validation error for negative max results, got nil")
 	}
-	
+
 	// Test zero max results
 	config = DefaultSearchServiceConfig()
 	config.Engine.MaxResults = 0
@@ -192,7 +192,7 @@ func TestSearchServiceConfig_Validate_InvalidEngineConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for zero max results, got nil")
 	}
-	
+
 	// Test negative default k
 	config = DefaultSearchServiceConfig()
 	config.Engine.DefaultK = -1
@@ -200,7 +200,7 @@ func TestSearchServiceConfig_Validate_InvalidEngineConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for negative default k, got nil")
 	}
-	
+
 	// Test zero default k
 	config = DefaultSearchServiceConfig()
 	config.Engine.DefaultK = 0
@@ -208,7 +208,7 @@ func TestSearchServiceConfig_Validate_InvalidEngineConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for zero default k, got nil")
 	}
-	
+
 	// Test invalid distance type
 	config = DefaultSearchServiceConfig()
 	config.Engine.DistanceType = "invalid"
@@ -220,14 +220,14 @@ func TestSearchServiceConfig_Validate_InvalidEngineConfig(t *testing.T) {
 
 func TestSearchServiceConfig_Validate_InvalidAPIConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
-	
+
 	// Test empty base path
 	config.API.HTTP.BasePath = ""
 	err := config.Validate()
 	if err == nil {
 		t.Error("Expected validation error for empty base path, got nil")
 	}
-	
+
 	// Test negative gRPC max message size
 	config = DefaultSearchServiceConfig()
 	config.API.GRPC.MaxMessageSize = -1
@@ -235,7 +235,7 @@ func TestSearchServiceConfig_Validate_InvalidAPIConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for negative gRPC max message size, got nil")
 	}
-	
+
 	// Test zero gRPC max message size
 	config = DefaultSearchServiceConfig()
 	config.API.GRPC.MaxMessageSize = 0
@@ -248,7 +248,7 @@ func TestSearchServiceConfig_Validate_InvalidAPIConfig(t *testing.T) {
 func TestSearchServiceConfig_Validate_InvalidAuthConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
 	config.Auth.Enabled = true
-	
+
 	// Test invalid auth type
 	config.Auth.Type = "invalid"
 	err := config.Validate()
@@ -260,14 +260,14 @@ func TestSearchServiceConfig_Validate_InvalidAuthConfig(t *testing.T) {
 func TestSearchServiceConfig_Validate_InvalidRateLimitConfig(t *testing.T) {
 	config := DefaultSearchServiceConfig()
 	config.RateLimit.Enabled = true
-	
+
 	// Test negative requests per second
 	config.RateLimit.RequestsPerSecond = -1.0
 	err := config.Validate()
 	if err == nil {
 		t.Error("Expected validation error for negative requests per second, got nil")
 	}
-	
+
 	// Test zero requests per second
 	config = DefaultSearchServiceConfig()
 	config.RateLimit.Enabled = true
@@ -276,7 +276,7 @@ func TestSearchServiceConfig_Validate_InvalidRateLimitConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for zero requests per second, got nil")
 	}
-	
+
 	// Test negative burst size
 	config = DefaultSearchServiceConfig()
 	config.RateLimit.Enabled = true
@@ -285,7 +285,7 @@ func TestSearchServiceConfig_Validate_InvalidRateLimitConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Expected validation error for negative burst size, got nil")
 	}
-	
+
 	// Test zero burst size
 	config = DefaultSearchServiceConfig()
 	config.RateLimit.Enabled = true
@@ -298,18 +298,18 @@ func TestSearchServiceConfig_Validate_InvalidRateLimitConfig(t *testing.T) {
 
 func TestGetSearchConfig(t *testing.T) {
 	config := GetSearchConfig(nil)
-	
+
 	if config == nil {
 		t.Fatal("Expected config to be returned, got nil")
 	}
-	
+
 	// Should return default config
 	defaultConfig := DefaultSearchServiceConfig()
-	
+
 	if config.Server.Host != defaultConfig.Server.Host {
 		t.Errorf("Expected Server.Host to be '%s', got '%s'", defaultConfig.Server.Host, config.Server.Host)
 	}
-	
+
 	if config.Server.Port != defaultConfig.Server.Port {
 		t.Errorf("Expected Server.Port to be %d, got %d", defaultConfig.Server.Port, config.Server.Port)
 	}
@@ -325,11 +325,11 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "valid config",
 			config: ServerConfig{
-				Host:         "localhost",
-				Port:         8080,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "localhost",
+				Port:           8080,
+				ReadTimeout:    30 * time.Second,
+				WriteTimeout:   30 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: false,
@@ -337,11 +337,11 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "empty host",
 			config: ServerConfig{
-				Host:         "",
-				Port:         8080,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "",
+				Port:           8080,
+				ReadTimeout:    30 * time.Second,
+				WriteTimeout:   30 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: true,
@@ -350,11 +350,11 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "invalid port - too low",
 			config: ServerConfig{
-				Host:         "localhost",
-				Port:         0,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "localhost",
+				Port:           0,
+				ReadTimeout:    30 * time.Second,
+				WriteTimeout:   30 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: true,
@@ -363,11 +363,11 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "invalid port - too high",
 			config: ServerConfig{
-				Host:         "localhost",
-				Port:         70000,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "localhost",
+				Port:           70000,
+				ReadTimeout:    30 * time.Second,
+				WriteTimeout:   30 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: true,
@@ -376,11 +376,11 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "negative read timeout",
 			config: ServerConfig{
-				Host:         "localhost",
-				Port:         8080,
-				ReadTimeout:  -1 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "localhost",
+				Port:           8080,
+				ReadTimeout:    -1 * time.Second,
+				WriteTimeout:   30 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: true,
@@ -389,33 +389,33 @@ func TestServerConfig_Validation(t *testing.T) {
 		{
 			name: "negative write timeout",
 			config: ServerConfig{
-				Host:         "localhost",
-				Port:         8080,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: -1 * time.Second,
-				IdleTimeout:  60 * time.Second,
+				Host:           "localhost",
+				Port:           8080,
+				ReadTimeout:    30 * time.Second,
+				WriteTimeout:   -1 * time.Second,
+				IdleTimeout:    60 * time.Second,
 				MaxHeaderBytes: 1048576,
 			},
 			wantErr: true,
 			errMsg:  "server write timeout must be positive",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &SearchServiceConfig{
-				Server: tt.config,
-				Engine: DefaultSearchServiceConfig().Engine,
-				API:    DefaultSearchServiceConfig().API,
-				Auth:   DefaultSearchServiceConfig().Auth,
+				Server:    tt.config,
+				Engine:    DefaultSearchServiceConfig().Engine,
+				API:       DefaultSearchServiceConfig().API,
+				Auth:      DefaultSearchServiceConfig().Auth,
 				RateLimit: DefaultSearchServiceConfig().RateLimit,
-				Metrics: DefaultSearchServiceConfig().Metrics,
-				Logging: DefaultSearchServiceConfig().Logging,
-				Health: DefaultSearchServiceConfig().Health,
+				Metrics:   DefaultSearchServiceConfig().Metrics,
+				Logging:   DefaultSearchServiceConfig().Logging,
+				Health:    DefaultSearchServiceConfig().Health,
 			}
-			
+
 			err := config.Validate()
-			
+
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("Expected validation error, got nil")
@@ -556,22 +556,22 @@ func TestEngineConfig_Validation(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &SearchServiceConfig{
-				Server: DefaultSearchServiceConfig().Server,
-				Engine: tt.config,
-				API:    DefaultSearchServiceConfig().API,
-				Auth:   DefaultSearchServiceConfig().Auth,
+				Server:    DefaultSearchServiceConfig().Server,
+				Engine:    tt.config,
+				API:       DefaultSearchServiceConfig().API,
+				Auth:      DefaultSearchServiceConfig().Auth,
 				RateLimit: DefaultSearchServiceConfig().RateLimit,
-				Metrics: DefaultSearchServiceConfig().Metrics,
-				Logging: DefaultSearchServiceConfig().Logging,
-				Health: DefaultSearchServiceConfig().Health,
+				Metrics:   DefaultSearchServiceConfig().Metrics,
+				Logging:   DefaultSearchServiceConfig().Logging,
+				Health:    DefaultSearchServiceConfig().Health,
 			}
-			
+
 			err := config.Validate()
-			
+
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("Expected validation error, got nil")

--- a/internal/search/grpc/server.go
+++ b/internal/search/grpc/server.go
@@ -6,21 +6,21 @@ import (
 	"math"
 	"time"
 
-	"vexdb/internal/metrics"
-	"vexdb/internal/search/config"
-	"vexdb/internal/search/response"
-	"vexdb/internal/search/validation"
-	"vexdb/internal/service"
-	"vexdb/internal/types"
+	"vxdb/internal/metrics"
+	"vxdb/internal/search/config"
+	"vxdb/internal/search/response"
+	"vxdb/internal/search/validation"
+	"vxdb/internal/service"
+	"vxdb/internal/types"
 
-	pb "vexdb/proto"
+	pb "vxdb/proto"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-    "google.golang.org/grpc/status"
-    emptypb "google.golang.org/protobuf/types/known/emptypb"
-    timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/grpc/status"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // SearchServer implements the gRPC SearchService
@@ -42,7 +42,7 @@ func NewSearchServer(cfg *config.SearchServiceConfig, logger *zap.Logger, metric
 		cfg.Engine.MaxResults,
 		100, // maxMetadataFilters
 	)
-	
+
 	formatter := response.NewFormatter(&response.ResponseConfig{
 		IncludeQueryVector: cfg.API.Response.IncludeQueryVector,
 		IncludeMetadata:    cfg.API.Response.IncludeMetadata,
@@ -83,12 +83,12 @@ func (s *SearchServer) Search(ctx context.Context, req *pb.SearchRequest) (*pb.S
 	}
 
 	// Convert protobuf request to internal types
-    queryVector := &types.Vector{
-        ID:        req.QueryVector.Id,
-        Data:      req.QueryVector.Data,
-        Metadata:  toMetadata(req.QueryVector.Metadata),
-        ClusterID: req.QueryVector.ClusterId,
-    }
+	queryVector := &types.Vector{
+		ID:        req.QueryVector.Id,
+		Data:      req.QueryVector.Data,
+		Metadata:  toMetadata(req.QueryVector.Metadata),
+		ClusterID: req.QueryVector.ClusterId,
+	}
 
 	// Set default k if not provided
 	k := int(req.K)
@@ -110,18 +110,18 @@ func (s *SearchServer) Search(ctx context.Context, req *pb.SearchRequest) (*pb.S
 	}
 
 	// Apply distance threshold if provided
-    if req.DistanceThreshold > 0 {
-        results = s.filterByDistance(results, float64(req.DistanceThreshold))
-    }
+	if req.DistanceThreshold > 0 {
+		results = s.filterByDistance(results, float64(req.DistanceThreshold))
+	}
 
 	// Convert results to protobuf format
 	pbResults := s.convertToProtoResults(results)
 
 	// Build response metadata
 	metadata := map[string]string{
-		"query_id":        queryID,
-		"execution_time":  time.Since(startTime).String(),
-		"distance_type":   s.config.Engine.DistanceType,
+		"query_id":       queryID,
+		"execution_time": time.Since(startTime).String(),
+		"distance_type":  s.config.Engine.DistanceType,
 	}
 
 	return &pb.SearchResponse{
@@ -179,12 +179,12 @@ func (s *SearchServer) MultiClusterSearch(ctx context.Context, req *pb.SearchReq
 	}
 
 	// Convert protobuf request to internal types
-    queryVector := &types.Vector{
-        ID:        req.QueryVector.Id,
-        Data:      req.QueryVector.Data,
-        Metadata:  toMetadata(req.QueryVector.Metadata),
-        ClusterID: req.QueryVector.ClusterId,
-    }
+	queryVector := &types.Vector{
+		ID:        req.QueryVector.Id,
+		Data:      req.QueryVector.Data,
+		Metadata:  toMetadata(req.QueryVector.Metadata),
+		ClusterID: req.QueryVector.ClusterId,
+	}
 
 	// Set default k if not provided
 	k := int(req.K)
@@ -212,9 +212,9 @@ func (s *SearchServer) MultiClusterSearch(ctx context.Context, req *pb.SearchReq
 	}
 
 	// Apply distance threshold if provided
-    if req.DistanceThreshold > 0 {
-        results = s.filterByDistance(results, float64(req.DistanceThreshold))
-    }
+	if req.DistanceThreshold > 0 {
+		results = s.filterByDistance(results, float64(req.DistanceThreshold))
+	}
 
 	// Convert results to protobuf format
 	pbResults := s.convertToProtoResults(results)
@@ -282,10 +282,10 @@ func (s *SearchServer) GetClusterInfo(ctx context.Context, req *pb.ClusterInfo) 
 	}
 
 	// Convert to protobuf format
-    pbClusterInfo := &pb.ClusterInfo{
-        Id:       clusterInfo.ID,
-        Metadata: clusterInfo.Metadata,
-    }
+	pbClusterInfo := &pb.ClusterInfo{
+		Id:       clusterInfo.ID,
+		Metadata: clusterInfo.Metadata,
+	}
 
 	return pbClusterInfo, nil
 }
@@ -299,15 +299,15 @@ func (s *SearchServer) GetClusterStatus(ctx context.Context, req *emptypb.Empty)
 		s.recordMetrics("grpc_get_cluster_status", time.Since(startTime), nil)
 	}()
 
-    if _, err := s.service.GetClusterStatus(ctx); err != nil {
-        s.logger.Error("Failed to get cluster status", zap.String("query_id", queryID), zap.Error(err))
-        return nil, status.Error(codes.Internal, "Failed to get cluster status")
-    }
+	if _, err := s.service.GetClusterStatus(ctx); err != nil {
+		s.logger.Error("Failed to get cluster status", zap.String("query_id", queryID), zap.Error(err))
+		return nil, status.Error(codes.Internal, "Failed to get cluster status")
+	}
 
-    // Convert to protobuf format (limited internal fields available)
-    pbClusterStatus := &pb.ClusterStatus{}
+	// Convert to protobuf format (limited internal fields available)
+	pbClusterStatus := &pb.ClusterStatus{}
 
-    return pbClusterStatus, nil
+	return pbClusterStatus, nil
 }
 
 // HealthCheck performs a health check
@@ -326,13 +326,13 @@ func (s *SearchServer) HealthCheck(ctx context.Context, req *pb.HealthCheckReque
 	}
 
 	// Convert to protobuf format
-    pbHealthResponse := &pb.HealthCheckResponse{
-        Healthy:   healthStatus.Status == "healthy",
-        Status:    healthStatus.Status,
-        Message:   healthStatus.Message,
-        Details:   healthStatus.Details,
-        Timestamp: timestamppb.Now(),
-    }
+	pbHealthResponse := &pb.HealthCheckResponse{
+		Healthy:   healthStatus.Status == "healthy",
+		Status:    healthStatus.Status,
+		Message:   healthStatus.Message,
+		Details:   healthStatus.Details,
+		Timestamp: timestamppb.Now(),
+	}
 
 	return pbHealthResponse, nil
 }
@@ -358,12 +358,12 @@ func (s *SearchServer) GetMetrics(ctx context.Context, req *pb.MetricsRequest) (
 		pbMetrics[key] = value
 	}
 
-    pbMetricsResponse := &pb.MetricsResponse{
-        Success:   true,
-        Message:   "Metrics retrieved successfully",
-        Metrics:   pbMetrics,
-        Timestamp: timestamppb.Now(),
-    }
+	pbMetricsResponse := &pb.MetricsResponse{
+		Success:   true,
+		Message:   "Metrics retrieved successfully",
+		Metrics:   pbMetrics,
+		Timestamp: timestamppb.Now(),
+	}
 
 	return pbMetricsResponse, nil
 }
@@ -407,8 +407,8 @@ func (s *SearchServer) GetConfig(ctx context.Context, req *emptypb.Empty) (*pb.C
 	}
 
 	pbConfigResponse := &pb.ConfigUpdateResponse{
-		Success: true,
-		Message: "Configuration retrieved successfully",
+		Success:        true,
+		Message:        "Configuration retrieved successfully",
 		AppliedUpdates: config,
 	}
 
@@ -456,12 +456,12 @@ func (s *SearchServer) convertToProtoResults(results []*types.SearchResult) []*p
 
 	for _, result := range results {
 		pbResult := &pb.SearchResult{
-            Vector: &pb.Vector{
-                Id:        result.Vector.ID,
-                Data:      result.Vector.Data,
-                Metadata:  toStringMetadata(result.Vector.Metadata),
-                ClusterId: result.Vector.ClusterID,
-            },
+			Vector: &pb.Vector{
+				Id:        result.Vector.ID,
+				Data:      result.Vector.Data,
+				Metadata:  toStringMetadata(result.Vector.Metadata),
+				ClusterId: result.Vector.ClusterID,
+			},
 			Distance:  float32(result.Distance),
 			Score:     float32(calculateScore(result.Distance)),
 			ClusterId: fmt.Sprintf("%d", result.Vector.ClusterID),
@@ -474,13 +474,13 @@ func (s *SearchServer) convertToProtoResults(results []*types.SearchResult) []*p
 }
 
 func (s *SearchServer) filterByDistance(results []*types.SearchResult, threshold float64) []*types.SearchResult {
-    filtered := make([]*types.SearchResult, 0, len(results))
-    for _, result := range results {
-        if result.Distance <= threshold {
-            filtered = append(filtered, result)
-        }
-    }
-    return filtered
+	filtered := make([]*types.SearchResult, 0, len(results))
+	for _, result := range results {
+		if result.Distance <= threshold {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }
 
 func (s *SearchServer) recordMetrics(operation string, duration time.Duration, err error) {
@@ -506,9 +506,9 @@ func calculateScore(distance float64) float64 {
 	if distance <= 0 {
 		return 1.0
 	}
-	
+
 	// Use exponential decay for score calculation
-    score := math.Exp(-distance / 10.0)
+	score := math.Exp(-distance / 10.0)
 	if score > 1.0 {
 		score = 1.0
 	}
@@ -516,23 +516,23 @@ func calculateScore(distance float64) float64 {
 }
 
 func toMetadata(in map[string]string) map[string]interface{} {
-    if in == nil {
-        return nil
-    }
-    out := make(map[string]interface{}, len(in))
-    for k, v := range in {
-        out[k] = v
-    }
-    return out
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func toStringMetadata(in map[string]interface{}) map[string]string {
-    if in == nil {
-        return nil
-    }
-    out := make(map[string]string, len(in))
-    for k, v := range in {
-        out[k] = fmt.Sprint(v)
-    }
-    return out
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = fmt.Sprint(v)
+	}
+	return out
 }

--- a/internal/search/integration/grpc_integration_test.go
+++ b/internal/search/integration/grpc_integration_test.go
@@ -3,20 +3,18 @@
 package integration
 
 import (
-
 	"context"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
-	"vexdb/internal/search/config"
-	searchgrpc "vexdb/internal/search/grpc"
-	"vexdb/internal/search/testutil"
-	"vexdb/internal/types"
+	"vxdb/internal/search/config"
+	searchgrpc "vxdb/internal/search/grpc"
+	"vxdb/internal/search/testutil"
+	"vxdb/internal/types"
 
-       pb "vexdb/proto"
-
+	pb "vxdb/proto"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -68,7 +66,6 @@ func TestSearchServerIntegration(t *testing.T) {
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
 
-
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
@@ -84,9 +81,9 @@ func TestSearchServerIntegration(t *testing.T) {
 
 	// Create client connection
 	ctx := context.Background()
-       conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-               return lis.Dial()
-       }), grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
@@ -344,13 +341,11 @@ func TestSearchServerStreaming(t *testing.T) {
 		},
 	}
 
-
 	mockService.SetSearchResults(testResults)
 
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
@@ -445,7 +440,6 @@ func TestSearchServerMultiClusterStreaming(t *testing.T) {
 			},
 			Distance: 0.5,
 		},
-
 	}
 
 	mockService.SetSearchResults(testResults)
@@ -453,7 +447,6 @@ func TestSearchServerMultiClusterStreaming(t *testing.T) {
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
@@ -548,7 +541,6 @@ func TestSearchServerHealthCheck(t *testing.T) {
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
 
-
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
@@ -611,7 +603,6 @@ func TestSearchServerGetMetrics(t *testing.T) {
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
@@ -681,7 +672,6 @@ func TestSearchServerConfiguration(t *testing.T) {
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
 
-
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
@@ -710,7 +700,6 @@ func TestSearchServerConfiguration(t *testing.T) {
 	// Test get configuration
 
 	req := &emptypb.Empty{}
-
 
 	resp, err := client.GetConfig(ctx, req)
 	if err != nil {
@@ -758,7 +747,6 @@ func TestSearchServerErrorHandling(t *testing.T) {
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
@@ -832,13 +820,11 @@ func TestSearchServerConcurrentRequests(t *testing.T) {
 		},
 	}
 
-
 	mockService.SetSearchResults(testResults)
 
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)
@@ -935,7 +921,6 @@ func TestSearchServerTimeout(t *testing.T) {
 	// Create gRPC server
 
 	server := searchgrpc.NewSearchServer(cfg, logger, nil, mockService)
-
 
 	// Create test listener
 	lis := bufconn.Listen(bufSize)

--- a/internal/search/integration/http_integration_test.go
+++ b/internal/search/integration/http_integration_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"vexdb/internal/search/api"
-	"vexdb/internal/search/auth"
-	"vexdb/internal/search/config"
-	"vexdb/internal/search/response"
-	"vexdb/internal/search/testutil"
-	"vexdb/internal/types"
+	"vxdb/internal/search/api"
+	"vxdb/internal/search/auth"
+	"vxdb/internal/search/config"
+	"vxdb/internal/search/response"
+	"vxdb/internal/search/testutil"
+	"vxdb/internal/types"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"

--- a/internal/search/integration/integration_stub_test.go
+++ b/internal/search/integration/integration_stub_test.go
@@ -2,7 +2,6 @@ package integration
 
 import "testing"
 
-
 // TestIntegrationStub ensures integration tests are skipped unless the
 // integration build tag is provided.
 func TestIntegrationStub(t *testing.T) {

--- a/internal/search/planner.go
+++ b/internal/search/planner.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/routing"
-	"vexdb/internal/types"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/routing"
+	"vxdb/internal/types"
 )
 
 // QueryPlanner handles query planning and optimization for similarity searches

--- a/internal/search/response/formatter.go
+++ b/internal/search/response/formatter.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 // Formatter handles formatting of search responses

--- a/internal/search/response/formatter_test.go
+++ b/internal/search/response/formatter_test.go
@@ -1,13 +1,13 @@
 package response
 
 import (
-       "encoding/json"
-       "fmt"
-       "math"
-       "testing"
-       "time"
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+	"time"
 
-       "vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 func TestNewFormatter(t *testing.T) {
@@ -19,13 +19,13 @@ func TestNewFormatter(t *testing.T) {
 		MaxResults:         100,
 		ResponseTimeout:    30 * time.Second,
 	}
-	
+
 	formatter := NewFormatter(config)
-	
+
 	if formatter == nil {
 		t.Fatal("Expected formatter to be created, got nil")
 	}
-	
+
 	if formatter.config != config {
 		t.Error("Expected formatter to use provided config")
 	}
@@ -33,24 +33,24 @@ func TestNewFormatter(t *testing.T) {
 
 func TestNewFormatter_DefaultConfig(t *testing.T) {
 	formatter := NewFormatter(nil)
-	
+
 	if formatter == nil {
 		t.Fatal("Expected formatter to be created with default config, got nil")
 	}
-	
+
 	if formatter.config == nil {
 		t.Fatal("Expected formatter to have default config, got nil")
 	}
-	
+
 	// Check default values
 	if !formatter.config.IncludeMetadata {
 		t.Error("Expected default IncludeMetadata to be true")
 	}
-	
+
 	if formatter.config.IncludeQueryVector {
 		t.Error("Expected default IncludeQueryVector to be false")
 	}
-	
+
 	if !formatter.config.IncludeTimestamps {
 		t.Error("Expected default IncludeTimestamps to be true")
 	}
@@ -58,7 +58,7 @@ func TestNewFormatter_DefaultConfig(t *testing.T) {
 
 func TestFormatSearchResponse_ValidResults(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	// Create test results
 	results := []*types.SearchResult{
 		{
@@ -86,12 +86,12 @@ func TestFormatSearchResponse_ValidResults(t *testing.T) {
 			Distance: 1.2,
 		},
 	}
-	
+
 	query := &types.Vector{
 		ID:   "query-vector",
 		Data: []float32{1.0, 2.0, 3.0},
 	}
-	
+
 	stats := &SearchStats{
 		TotalResults:    2,
 		ReturnedResults: 2,
@@ -102,45 +102,44 @@ func TestFormatSearchResponse_ValidResults(t *testing.T) {
 		NodesQueried:    1,
 		ClustersQueried: 2,
 	}
-	
+
 	response := formatter.FormatSearchResponse(results, query, 10, "test-query-123", stats)
-	
+
 	if response == nil {
 		t.Fatal("Expected response to be created, got nil")
 	}
-	
+
 	if !response.Success {
 		t.Error("Expected response to be successful")
 	}
-	
+
 	if response.QueryID != "test-query-123" {
 		t.Errorf("Expected QueryID to be 'test-query-123', got '%s'", response.QueryID)
 	}
-	
+
 	if len(response.Results) != 2 {
 		t.Errorf("Expected 2 results, got %d", len(response.Results))
 	}
-	
-	
+
 	if response.Stats == nil {
 		t.Fatal("Expected stats to be included")
 	}
-	
+
 	if response.Stats.TotalResults != 2 {
 		t.Errorf("Expected stats.TotalResults to be 2, got %d", response.Stats.TotalResults)
 	}
-	
+
 	// Check first result
 	if len(response.Results) > 0 {
 		firstResult := response.Results[0]
 		if firstResult.ID != "vector1" {
 			t.Errorf("Expected first result ID to be 'vector1', got '%s'", firstResult.ID)
 		}
-		
+
 		if firstResult.Distance != 0.5 {
 			t.Errorf("Expected first result distance to be 0.5, got %f", firstResult.Distance)
 		}
-		
+
 		// Check that metadata is included (default config includes metadata)
 		if firstResult.Metadata == nil {
 			t.Error("Expected metadata to be included")
@@ -154,38 +153,38 @@ func TestFormatSearchResponse_ValidResults(t *testing.T) {
 
 func TestFormatSearchResponse_EmptyResults(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	results := []*types.SearchResult{}
 	query := &types.Vector{
 		ID:   "query-vector",
 		Data: []float32{1.0, 2.0, 3.0},
 	}
-	
+
 	stats := &SearchStats{
 		TotalResults:    0,
 		ReturnedResults: 0,
 		ExecutionTime:   50 * time.Millisecond,
 	}
-	
+
 	response := formatter.FormatSearchResponse(results, query, 10, "test-query-456", stats)
-	
+
 	if response == nil {
 		t.Fatal("Expected response to be created, got nil")
 	}
-	
+
 	if !response.Success {
 		t.Error("Expected response to be successful even with no results")
 	}
-	
+
 	if len(response.Results) != 0 {
 		t.Errorf("Expected 0 results, got %d", len(response.Results))
 	}
-	
+
 }
 
 func TestFormatErrorResponse(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	err := fmt.Errorf("test error message")
 	queryID := "test-query-789"
 	code := "TEST_ERROR"
@@ -193,33 +192,33 @@ func TestFormatErrorResponse(t *testing.T) {
 		"detail1": "value1",
 		"detail2": 42,
 	}
-	
+
 	response := formatter.FormatErrorResponse(err, queryID, code, details)
-	
+
 	if response == nil {
 		t.Fatal("Expected error response to be created, got nil")
 	}
-	
+
 	if response.Success {
 		t.Error("Expected error response to have Success=false")
 	}
-	
+
 	if response.Error != "test error message" {
 		t.Errorf("Expected Error to be 'test error message', got '%s'", response.Error)
 	}
-	
+
 	if response.Message != "An error occurred while processing your request" {
 		t.Errorf("Expected default message, got '%s'", response.Message)
 	}
-	
+
 	if response.Code != code {
 		t.Errorf("Expected Code to be '%s', got '%s'", code, response.Code)
 	}
-	
+
 	if response.QueryID != queryID {
 		t.Errorf("Expected QueryID to be '%s', got '%s'", queryID, response.QueryID)
 	}
-	
+
 	if response.Details == nil {
 		t.Error("Expected details to be included")
 	}
@@ -227,7 +226,7 @@ func TestFormatErrorResponse(t *testing.T) {
 
 func TestFormatValidationErrorResponse(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	errors := []ValidationError{
 		{
 			Field:   "vector",
@@ -240,40 +239,40 @@ func TestFormatValidationErrorResponse(t *testing.T) {
 			Value:   -1,
 		},
 	}
-	
+
 	queryID := "test-query-999"
-	
+
 	response := formatter.FormatValidationErrorResponse(errors, queryID)
-	
+
 	if response == nil {
 		t.Fatal("Expected validation error response to be created, got nil")
 	}
-	
+
 	if response.Success {
 		t.Error("Expected validation error response to have Success=false")
 	}
-	
+
 	if response.Error != "validation_failed" {
 		t.Errorf("Expected Error to be 'validation_failed', got '%s'", response.Error)
 	}
-	
+
 	if response.Message != "Request validation failed" {
 		t.Errorf("Expected Message to be 'Request validation failed', got '%s'", response.Message)
 	}
-	
+
 	if response.Code != "VALIDATION_ERROR" {
 		t.Errorf("Expected Code to be 'VALIDATION_ERROR', got '%s'", response.Code)
 	}
-	
+
 	if response.Details == nil {
 		t.Fatal("Expected details to be included")
 	}
-	
+
 	validationErrors, ok := response.Details["validation_errors"].([]ValidationError)
 	if !ok {
 		t.Fatal("Expected validation_errors in details")
 	}
-	
+
 	if len(validationErrors) != 2 {
 		t.Errorf("Expected 2 validation errors, got %d", len(validationErrors))
 	}
@@ -301,15 +300,15 @@ func TestCalculateScore(t *testing.T) {
 			expected: 0.00004539992976248485, // exp(-100/10)
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			score := calculateScore(tt.distance)
-			
+
 			if math.Abs(score-tt.expected) > 0.0001 {
 				t.Errorf("Expected score %f, got %f", tt.expected, score)
 			}
-			
+
 			if score < 0 || score > 1 {
 				t.Errorf("Expected score to be between 0 and 1, got %f", score)
 			}
@@ -364,11 +363,11 @@ func TestGetErrorMessage(t *testing.T) {
 			expected: "Unknown error",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			message := getErrorMessage(tt.err)
-			
+
 			if message != tt.expected {
 				t.Errorf("Expected message '%s', got '%s'", tt.expected, message)
 			}
@@ -378,31 +377,31 @@ func TestGetErrorMessage(t *testing.T) {
 
 func TestToJSON(t *testing.T) {
 	formatter := NewFormatter(&ResponseConfig{PrettyPrint: false})
-	
+
 	response := &SearchResponse{
 		Success:   true,
 		QueryID:   "test-query",
 		Results:   []SearchResult{},
 		Timestamp: time.Now(),
 	}
-	
+
 	jsonData, err := formatter.ToJSON(response)
-	
+
 	if err != nil {
 		t.Errorf("Expected no error converting to JSON, got: %v", err)
 	}
-	
+
 	if len(jsonData) == 0 {
 		t.Error("Expected non-empty JSON data")
 	}
-	
+
 	// Verify it's valid JSON
 	var parsed map[string]interface{}
 	err = json.Unmarshal(jsonData, &parsed)
 	if err != nil {
 		t.Errorf("Expected valid JSON, got parsing error: %v", err)
 	}
-	
+
 	if parsed["success"] != true {
 		t.Error("Expected parsed JSON to have success=true")
 	}
@@ -410,26 +409,26 @@ func TestToJSON(t *testing.T) {
 
 func TestToJSON_PrettyPrint(t *testing.T) {
 	formatter := NewFormatter(&ResponseConfig{PrettyPrint: true})
-	
+
 	response := &SearchResponse{
 		Success:   true,
 		QueryID:   "test-query",
 		Results:   []SearchResult{},
 		Timestamp: time.Now(),
 	}
-	
+
 	jsonData, err := formatter.ToJSON(response)
-	
+
 	if err != nil {
 		t.Errorf("Expected no error converting to JSON, got: %v", err)
 	}
-	
+
 	// Pretty printed JSON should contain newlines and indentation
 	jsonStr := string(jsonData)
 	if !contains(jsonStr, "\n") {
 		t.Error("Expected pretty-printed JSON to contain newlines")
 	}
-	
+
 	if !contains(jsonStr, "  ") {
 		t.Error("Expected pretty-printed JSON to contain indentation")
 	}
@@ -437,7 +436,7 @@ func TestToJSON_PrettyPrint(t *testing.T) {
 
 func TestFormatBatchResponse(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	// Create test batch results
 	results := [][]*types.SearchResult{
 		{
@@ -459,72 +458,72 @@ func TestFormatBatchResponse(t *testing.T) {
 			},
 		},
 	}
-	
+
 	queries := []*types.Vector{
 		{ID: "query1", Data: []float32{1.0, 2.0}},
 		{ID: "query2", Data: []float32{3.0, 4.0}},
 	}
-	
+
 	queryIDs := []string{"batch-1", "batch-2"}
 	stats := []*SearchStats{
 		{TotalResults: 1, ReturnedResults: 1, ExecutionTime: 50 * time.Millisecond},
 		{TotalResults: 1, ReturnedResults: 1, ExecutionTime: 60 * time.Millisecond},
 	}
-	
+
 	response := formatter.FormatBatchResponse(results, queries, 10, queryIDs, stats)
-	
+
 	if response == nil {
 		t.Fatal("Expected batch response to be created, got nil")
 	}
-	
+
 	if !response.Success {
 		t.Error("Expected batch response to be successful")
 	}
-	
+
 	if response.BatchSize != 2 {
 		t.Errorf("Expected BatchSize to be 2, got %d", response.BatchSize)
 	}
-	
+
 	if len(response.Results) != 2 {
 		t.Errorf("Expected 2 individual results, got %d", len(response.Results))
 	}
-	
-       // Success is a boolean; verify no failures in individual responses
-       for _, r := range response.Results {
-               if !r.Success {
-                       t.Error("Expected all individual responses to be successful")
-               }
-       }
+
+	// Success is a boolean; verify no failures in individual responses
+	for _, r := range response.Results {
+		if !r.Success {
+			t.Error("Expected all individual responses to be successful")
+		}
+	}
 }
 
 func TestFormatHealthResponse(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	healthy := true
 	status := "healthy"
 	details := map[string]interface{}{
-		"uptime": "1h30m",
+		"uptime":  "1h30m",
 		"version": "1.0.0",
 	}
-	
+
 	response := formatter.FormatHealthResponse(healthy, status, details)
-	
+
 	if response == nil {
 		t.Fatal("Expected health response to be created, got nil")
 	}
-	
+
 	if !response.Success {
 		t.Error("Expected health response to be successful")
 	}
-	
+
 	if response.Status != status {
 		t.Errorf("Expected Status to be '%s', got '%s'", status, response.Status)
 	}
-	
+
 	if response.Details == nil {
 		t.Fatal("Expected details to be included")
 	}
-	
+
 	if response.Details["uptime"] != "1h30m" {
 		t.Errorf("Expected uptime detail to be '1h30m', got '%v'", response.Details["uptime"])
 	}
@@ -532,27 +531,27 @@ func TestFormatHealthResponse(t *testing.T) {
 
 func TestFormatMetricsResponse(t *testing.T) {
 	formatter := NewFormatter(DefaultResponseConfig())
-	
+
 	metrics := map[string]interface{}{
 		"requests_total": 1000,
 		"avg_latency":    0.05,
 		"error_rate":     0.01,
 	}
-	
+
 	response := formatter.FormatMetricsResponse(metrics)
-	
+
 	if response == nil {
 		t.Fatal("Expected metrics response to be created, got nil")
 	}
-	
+
 	if !response.Success {
 		t.Error("Expected metrics response to be successful")
 	}
-	
+
 	if response.Metrics == nil {
 		t.Fatal("Expected metrics to be included")
 	}
-	
+
 	if response.Metrics["requests_total"] != 1000 {
 		t.Errorf("Expected requests_total to be 1000, got %v", response.Metrics["requests_total"])
 	}

--- a/internal/search/result_merger.go
+++ b/internal/search/result_merger.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 // ResultMerger handles merging search results from multiple nodes

--- a/internal/search/server/grpc.go
+++ b/internal/search/server/grpc.go
@@ -1,20 +1,20 @@
 package server
 
 import (
-    "context"
-    "fmt"
-    "net"
-    "time"
+	"context"
+	"fmt"
+	"net"
+	"time"
 
-    "vexdb/internal/metrics"
-    "vexdb/internal/search/config"
-    searchgrpc "vexdb/internal/search/grpc"
-    "vexdb/internal/service"
+	"vxdb/internal/metrics"
+	"vxdb/internal/search/config"
+	searchgrpc "vxdb/internal/search/grpc"
+	"vxdb/internal/service"
 
-    "go.uber.org/zap"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/keepalive"
-    "google.golang.org/grpc/reflection"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/reflection"
 )
 
 // GRPCServer represents the gRPC server for the search service
@@ -60,7 +60,7 @@ func (s *GRPCServer) Start(ctx context.Context) error {
 	s.server = grpc.NewServer(opts...)
 
 	// Create and register search server
-    searchServer := searchgrpc.NewSearchServer(s.config, s.logger, s.metrics, s.searchService)
+	searchServer := searchgrpc.NewSearchServer(s.config, s.logger, s.metrics, s.searchService)
 	searchServer.RegisterServer(s.server)
 
 	// Register reflection service for development
@@ -250,8 +250,8 @@ func (s *GRPCServer) GetServiceInfo() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"status":    "running",
-		"address":   s.getAddress(),
-		"services":  s.server.GetServiceInfo(),
+		"status":   "running",
+		"address":  s.getAddress(),
+		"services": s.server.GetServiceInfo(),
 	}
 }

--- a/internal/search/server/http.go
+++ b/internal/search/server/http.go
@@ -1,18 +1,18 @@
 package server
 
 import (
-    "context"
-    "crypto/tls"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "time"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
-    "vexdb/internal/metrics"
-    "vexdb/internal/search/api"
-    "vexdb/internal/search/auth"
-    "vexdb/internal/search/config"
-    "vexdb/internal/service"
+	"vxdb/internal/metrics"
+	"vxdb/internal/search/api"
+	"vxdb/internal/search/auth"
+	"vxdb/internal/search/config"
+	"vxdb/internal/service"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
@@ -20,12 +20,12 @@ import (
 
 // HTTPServer represents the HTTP server for the search service
 type HTTPServer struct {
-	config       *config.SearchServiceConfig
-	logger       *zap.Logger
-	metrics      *metrics.Collector
+	config        *config.SearchServiceConfig
+	logger        *zap.Logger
+	metrics       *metrics.Collector
 	searchService service.SearchService
-	server       *http.Server
-	router       *mux.Router
+	server        *http.Server
+	router        *mux.Router
 }
 
 // NewHTTPServer creates a new HTTP server for the search service
@@ -209,9 +209,9 @@ func (s *HTTPServer) createMetricsMiddleware() mux.MiddlewareFunc {
 			// Record metrics
 			duration := time.Since(start)
 			s.metrics.RecordHistogram("http_request_duration_seconds", duration.Seconds(), map[string]string{
-				"method":     r.Method,
-				"path":       r.URL.Path,
-				"status":     fmt.Sprintf("%d", wrapper.statusCode),
+				"method": r.Method,
+				"path":   r.URL.Path,
+				"status": fmt.Sprintf("%d", wrapper.statusCode),
 			})
 
 			s.metrics.RecordCounter("http_requests_total", 1, map[string]string{
@@ -238,10 +238,10 @@ func (s *HTTPServer) createRecoveryMiddleware() mux.MiddlewareFunc {
 					// Send error response
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusInternalServerError)
-					
-                    // Simple JSON encoding
-                    jsonResponse := fmt.Sprintf(`{"success":false,"error":"internal_server_error","message":"An internal server error occurred","timestamp":"%s"}`,
-                        time.Now().Format(time.RFC3339))
+
+					// Simple JSON encoding
+					jsonResponse := fmt.Sprintf(`{"success":false,"error":"internal_server_error","message":"An internal server error occurred","timestamp":"%s"}`,
+						time.Now().Format(time.RFC3339))
 
 					w.Write([]byte(jsonResponse))
 				}
@@ -299,23 +299,23 @@ func (s *HTTPServer) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	// Get metrics from the metrics collector
 	// For now, just return a simple response
 	// In a real implementation, this would get metrics from the metrics collector
-	
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("# VexDB Search Service Metrics\n"))
+	w.Write([]byte("# VxDB Search Service Metrics\n"))
 }
 
 func (s *HTTPServer) handleRoot(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"service":   "VexDB Search Service",
+		"service":   "VxDB Search Service",
 		"version":   "1.0.0",
 		"status":    "running",
 		"timestamp": time.Now().Format(time.RFC3339),
 		"endpoints": map[string]interface{}{
-			"health":        "/health",
+			"health":          "/health",
 			"health_detailed": "/health/detailed",
-			"metrics":       s.config.Metrics.Path,
-			"api":           s.config.API.HTTP.BasePath,
+			"metrics":         s.config.Metrics.Path,
+			"api":             s.config.API.HTTP.BasePath,
 		},
 	}
 

--- a/internal/search/service/service.go
+++ b/internal/search/service/service.go
@@ -6,11 +6,11 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/metrics"
-	searchconfig "vexdb/internal/search/config"
-	"vexdb/internal/service"
-	"vexdb/internal/storage/search"
-	"vexdb/internal/types"
+	"vxdb/internal/metrics"
+	searchconfig "vxdb/internal/search/config"
+	"vxdb/internal/service"
+	"vxdb/internal/storage/search"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/search/test_coverage_report.md
+++ b/internal/search/test_coverage_report.md
@@ -1,8 +1,8 @@
-# VEXDB Search Service Test Coverage Report
+# VXDB Search Service Test Coverage Report
 
 ## Overview
 
-This report provides a comprehensive overview of the test coverage for the VEXDB search service components implemented in Phase 10. The testing infrastructure includes unit tests, integration tests, performance benchmarks, and test utilities.
+This report provides a comprehensive overview of the test coverage for the VXDB search service components implemented in Phase 10. The testing infrastructure includes unit tests, integration tests, performance benchmarks, and test utilities.
 
 ## Test Components
 
@@ -180,7 +180,7 @@ This report provides a comprehensive overview of the test coverage for the VEXDB
 [... additional test results ...]
 
 PASS
-ok      vexdb/internal/search/validation  0.123s
+ok      vxdb/internal/search/validation  0.123s
 ```
 
 ### Benchmark Results
@@ -307,7 +307,7 @@ BenchmarkJSONSerialization/PrettyJSON-8                   200000      6234 ns/op
 
 ## Conclusion
 
-The VEXDB search service has comprehensive test coverage with:
+The VXDB search service has comprehensive test coverage with:
 - **94% average line coverage** across core components
 - **87% average branch coverage** for complex logic paths
 - **100% function coverage** for all public APIs

--- a/internal/search/testutil/mocks.go
+++ b/internal/search/testutil/mocks.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 // MockSearchService implements a mock search service for testing

--- a/internal/search/timeout_test.go
+++ b/internal/search/timeout_test.go
@@ -9,11 +9,11 @@ import (
 func TestNewSearchTimeout(t *testing.T) {
 	defaultTimeout := 30 * time.Second
 	timeout := NewSearchTimeout(defaultTimeout)
-	
+
 	if timeout == nil {
 		t.Fatal("Expected timeout handler to be created, got nil")
 	}
-	
+
 	if timeout.defaultTimeout != defaultTimeout {
 		t.Errorf("Expected default timeout to be %v, got %v", defaultTimeout, timeout.defaultTimeout)
 	}
@@ -21,21 +21,21 @@ func TestNewSearchTimeout(t *testing.T) {
 
 func TestSearchTimeout_WithTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(1 * time.Second)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithTimeout(ctx)
 	defer cancel()
-	
+
 	if ctxWithTimeout == nil {
 		t.Fatal("Expected context with timeout to be created, got nil")
 	}
-	
+
 	// Verify that the context has a deadline
 	deadline, ok := ctxWithTimeout.Deadline()
 	if !ok {
 		t.Fatal("Expected context to have a deadline")
 	}
-	
+
 	// Check that the deadline is approximately 1 second from now
 	expectedDeadline := time.Now().Add(1 * time.Second)
 	diff := deadline.Sub(expectedDeadline)
@@ -46,22 +46,22 @@ func TestSearchTimeout_WithTimeout(t *testing.T) {
 
 func TestSearchTimeout_WithCustomTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(30 * time.Second)
-	
+
 	ctx := context.Background()
 	customTimeout := 5 * time.Second
 	ctxWithTimeout, cancel := timeout.WithCustomTimeout(ctx, customTimeout)
 	defer cancel()
-	
+
 	if ctxWithTimeout == nil {
 		t.Fatal("Expected context with custom timeout to be created, got nil")
 	}
-	
+
 	// Verify that the context has a deadline
 	deadline, ok := ctxWithTimeout.Deadline()
 	if !ok {
 		t.Fatal("Expected context to have a deadline")
 	}
-	
+
 	// Check that the deadline is approximately 5 seconds from now
 	expectedDeadline := time.Now().Add(5 * time.Second)
 	diff := deadline.Sub(expectedDeadline)
@@ -73,9 +73,9 @@ func TestSearchTimeout_WithCustomTimeout(t *testing.T) {
 func TestSearchTimeout_GetDefaultTimeout(t *testing.T) {
 	defaultTimeout := 45 * time.Second
 	timeout := NewSearchTimeout(defaultTimeout)
-	
+
 	retrievedTimeout := timeout.GetDefaultTimeout()
-	
+
 	if retrievedTimeout != defaultTimeout {
 		t.Errorf("Expected GetDefaultTimeout to return %v, got %v", defaultTimeout, retrievedTimeout)
 	}
@@ -83,12 +83,12 @@ func TestSearchTimeout_GetDefaultTimeout(t *testing.T) {
 
 func TestSearchTimeout_SetDefaultTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(30 * time.Second)
-	
+
 	newTimeout := 60 * time.Second
 	timeout.SetDefaultTimeout(newTimeout)
-	
+
 	retrievedTimeout := timeout.GetDefaultTimeout()
-	
+
 	if retrievedTimeout != newTimeout {
 		t.Errorf("Expected GetDefaultTimeout to return %v after setting, got %v", newTimeout, retrievedTimeout)
 	}
@@ -96,11 +96,11 @@ func TestSearchTimeout_SetDefaultTimeout(t *testing.T) {
 
 func TestSearchTimeout_ContextCancellation(t *testing.T) {
 	timeout := NewSearchTimeout(100 * time.Millisecond)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithTimeout(ctx)
 	defer cancel()
-	
+
 	// Wait for the context to be cancelled
 	select {
 	case <-ctxWithTimeout.Done():
@@ -108,7 +108,7 @@ func TestSearchTimeout_ContextCancellation(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		t.Error("Expected context to be cancelled within 200ms, but it wasn't")
 	}
-	
+
 	if ctxWithTimeout.Err() != context.DeadlineExceeded {
 		t.Errorf("Expected context error to be DeadlineExceeded, got %v", ctxWithTimeout.Err())
 	}
@@ -116,11 +116,11 @@ func TestSearchTimeout_ContextCancellation(t *testing.T) {
 
 func TestSearchTimeout_ContextCancellationWithCustomTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(30 * time.Second)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithCustomTimeout(ctx, 50*time.Millisecond)
 	defer cancel()
-	
+
 	// Wait for the context to be cancelled
 	select {
 	case <-ctxWithTimeout.Done():
@@ -128,7 +128,7 @@ func TestSearchTimeout_ContextCancellationWithCustomTimeout(t *testing.T) {
 	case <-time.After(150 * time.Millisecond):
 		t.Error("Expected context to be cancelled within 150ms, but it wasn't")
 	}
-	
+
 	if ctxWithTimeout.Err() != context.DeadlineExceeded {
 		t.Errorf("Expected context error to be DeadlineExceeded, got %v", ctxWithTimeout.Err())
 	}
@@ -136,16 +136,16 @@ func TestSearchTimeout_ContextCancellationWithCustomTimeout(t *testing.T) {
 
 func TestSearchTimeout_ManualCancellation(t *testing.T) {
 	timeout := NewSearchTimeout(30 * time.Second)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithTimeout(ctx)
-	
+
 	// Cancel the context manually
 	cancel()
-	
+
 	// Wait a bit to ensure cancellation is processed
 	time.Sleep(10 * time.Millisecond)
-	
+
 	if ctxWithTimeout.Err() != context.Canceled {
 		t.Errorf("Expected context error to be Canceled, got %v", ctxWithTimeout.Err())
 	}
@@ -153,15 +153,15 @@ func TestSearchTimeout_ManualCancellation(t *testing.T) {
 
 func TestSearchTimeout_NestedContexts(t *testing.T) {
 	timeout := NewSearchTimeout(1 * time.Second)
-	
+
 	// Create a parent context with a shorter timeout
 	parentCtx, parentCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer parentCancel()
-	
+
 	// Create a child context with a longer timeout
 	childCtx, childCancel := timeout.WithCustomTimeout(parentCtx, 2*time.Second)
 	defer childCancel()
-	
+
 	// The child context should be cancelled when the parent context expires
 	select {
 	case <-childCtx.Done():
@@ -169,7 +169,7 @@ func TestSearchTimeout_NestedContexts(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Error("Expected child context to be cancelled when parent expires, but it wasn't")
 	}
-	
+
 	if childCtx.Err() != context.DeadlineExceeded {
 		t.Errorf("Expected child context error to be DeadlineExceeded, got %v", childCtx.Err())
 	}
@@ -177,15 +177,15 @@ func TestSearchTimeout_NestedContexts(t *testing.T) {
 
 func TestSearchTimeout_ConcurrentUsage(t *testing.T) {
 	timeout := NewSearchTimeout(100 * time.Millisecond)
-	
+
 	// Test concurrent creation of contexts
 	done := make(chan bool, 10)
-	
+
 	for i := 0; i < 10; i++ {
 		go func() {
 			ctx, cancel := timeout.WithTimeout(context.Background())
 			defer cancel()
-			
+
 			select {
 			case <-ctx.Done():
 				done <- true
@@ -194,7 +194,7 @@ func TestSearchTimeout_ConcurrentUsage(t *testing.T) {
 			}
 		}()
 	}
-	
+
 	// Wait for all goroutines to complete
 	successCount := 0
 	for i := 0; i < 10; i++ {
@@ -202,7 +202,7 @@ func TestSearchTimeout_ConcurrentUsage(t *testing.T) {
 			successCount++
 		}
 	}
-	
+
 	if successCount != 10 {
 		t.Errorf("Expected all 10 contexts to be cancelled, got %d", successCount)
 	}
@@ -210,11 +210,11 @@ func TestSearchTimeout_ConcurrentUsage(t *testing.T) {
 
 func TestSearchTimeout_ZeroTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(0)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithTimeout(ctx)
 	defer cancel()
-	
+
 	// Context with zero timeout should be cancelled immediately
 	select {
 	case <-ctxWithTimeout.Done():
@@ -222,7 +222,7 @@ func TestSearchTimeout_ZeroTimeout(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Error("Expected context with zero timeout to be cancelled immediately")
 	}
-	
+
 	if ctxWithTimeout.Err() != context.DeadlineExceeded {
 		t.Errorf("Expected context error to be DeadlineExceeded, got %v", ctxWithTimeout.Err())
 	}
@@ -230,11 +230,11 @@ func TestSearchTimeout_ZeroTimeout(t *testing.T) {
 
 func TestSearchTimeout_VeryLongTimeout(t *testing.T) {
 	timeout := NewSearchTimeout(24 * time.Hour)
-	
+
 	ctx := context.Background()
 	ctxWithTimeout, cancel := timeout.WithTimeout(ctx)
 	defer cancel()
-	
+
 	// Context should not be cancelled within a short time
 	select {
 	case <-ctxWithTimeout.Done():
@@ -242,7 +242,7 @@ func TestSearchTimeout_VeryLongTimeout(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		// Context is still active as expected
 	}
-	
+
 	if ctxWithTimeout.Err() != nil {
 		t.Errorf("Expected context with long timeout to have no error yet, got %v", ctxWithTimeout.Err())
 	}

--- a/internal/search/validation/validator_test.go
+++ b/internal/search/validation/validator_test.go
@@ -1,32 +1,32 @@
 package validation
 
 import (
-       "math"
-       "strings"
-       "testing"
+	"math"
+	"strings"
+	"testing"
 
-       "vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 func TestNewSearchRequestValidator(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	if validator == nil {
 		t.Fatal("Expected validator to be created, got nil")
 	}
-	
+
 	if validator.maxVectorDim != 1000 {
 		t.Errorf("Expected maxVectorDim to be 1000, got %d", validator.maxVectorDim)
 	}
-	
+
 	if validator.maxK != 100 {
 		t.Errorf("Expected maxK to be 100, got %d", validator.maxK)
 	}
-	
+
 	if validator.maxResults != 1000 {
 		t.Errorf("Expected maxResults to be 1000, got %d", validator.maxResults)
 	}
-	
+
 	if validator.maxMetadataFilters != 50 {
 		t.Errorf("Expected maxMetadataFilters to be 50, got %d", validator.maxMetadataFilters)
 	}
@@ -34,14 +34,14 @@ func TestNewSearchRequestValidator(t *testing.T) {
 
 func TestValidateSearchRequest_ValidRequest(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	query := &types.Vector{
 		ID:   "test-vector",
 		Data: []float32{1.0, 2.0, 3.0, 4.0, 5.0},
 	}
-	
+
 	err := validator.ValidateSearchRequest(query, 10, nil)
-	
+
 	if err != nil {
 		t.Errorf("Expected no error for valid request, got: %v", err)
 	}
@@ -49,80 +49,80 @@ func TestValidateSearchRequest_ValidRequest(t *testing.T) {
 
 func TestValidateSearchRequest_NilQuery(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateSearchRequest(nil, 10, nil)
-	
+
 	if err == nil {
 		t.Error("Expected error for nil query, got nil")
 	}
-	
-       if !strings.Contains(err.Error(), "query vector cannot be nil") {
-               t.Errorf("Expected error containing 'query vector cannot be nil', got: %v", err)
-       }
+
+	if !strings.Contains(err.Error(), "query vector cannot be nil") {
+		t.Errorf("Expected error containing 'query vector cannot be nil', got: %v", err)
+	}
 }
 
 func TestValidateSearchRequest_EmptyVector(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	query := &types.Vector{
 		ID:   "test-vector",
 		Data: []float32{},
 	}
-	
+
 	err := validator.ValidateSearchRequest(query, 10, nil)
-	
+
 	if err == nil {
 		t.Error("Expected error for empty vector, got nil")
 	}
-	
-       if !strings.Contains(err.Error(), "query vector cannot be empty") {
-               t.Errorf("Expected error containing 'query vector cannot be empty', got: %v", err)
-       }
+
+	if !strings.Contains(err.Error(), "query vector cannot be empty") {
+		t.Errorf("Expected error containing 'query vector cannot be empty', got: %v", err)
+	}
 }
 
 func TestValidateSearchRequest_VectorTooLarge(t *testing.T) {
 	validator := NewSearchRequestValidator(5, 100, 1000, 50)
-	
+
 	query := &types.Vector{
 		ID:   "test-vector",
 		Data: []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, // 6 dimensions, max is 5
 	}
-	
+
 	err := validator.ValidateSearchRequest(query, 10, nil)
-	
+
 	if err == nil {
 		t.Error("Expected error for vector too large, got nil")
 	}
-	
-       expectedMsg := "query vector dimension 6 exceeds maximum 5"
-       if !strings.Contains(err.Error(), expectedMsg) {
-               t.Errorf("Expected error containing '%s', got: %v", expectedMsg, err)
-       }
+
+	expectedMsg := "query vector dimension 6 exceeds maximum 5"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected error containing '%s', got: %v", expectedMsg, err)
+	}
 }
 
 func TestValidateSearchRequest_InvalidVectorValues(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	// Test with NaN
 	query := &types.Vector{
 		ID:   "test-vector",
 		Data: []float32{1.0, float32(math.NaN()), 3.0},
 	}
-	
+
 	err := validator.ValidateSearchRequest(query, 10, nil)
-	
+
 	if err == nil {
 		t.Error("Expected error for NaN value, got nil")
 	}
-	
+
 	// Test with Inf
 	query = &types.Vector{
 		ID:   "test-vector",
 		Data: []float32{1.0, float32(math.Inf(1)), 3.0},
 	}
-	
+
 	err = validator.ValidateSearchRequest(query, 10, nil)
-	
+
 	if err == nil {
 		t.Error("Expected error for Inf value, got nil")
 	}
@@ -130,9 +130,9 @@ func TestValidateSearchRequest_InvalidVectorValues(t *testing.T) {
 
 func TestValidateK_ValidK(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.validateK(50)
-	
+
 	if err != nil {
 		t.Errorf("Expected no error for valid k, got: %v", err)
 	}
@@ -140,13 +140,13 @@ func TestValidateK_ValidK(t *testing.T) {
 
 func TestValidateK_ZeroK(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.validateK(0)
-	
+
 	if err == nil {
 		t.Error("Expected error for zero k, got nil")
 	}
-	
+
 	if err.Error() != "k must be positive, got 0" {
 		t.Errorf("Expected 'k must be positive, got 0', got: %v", err)
 	}
@@ -154,13 +154,13 @@ func TestValidateK_ZeroK(t *testing.T) {
 
 func TestValidateK_NegativeK(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.validateK(-5)
-	
+
 	if err == nil {
 		t.Error("Expected error for negative k, got nil")
 	}
-	
+
 	if err.Error() != "k must be positive, got -5" {
 		t.Errorf("Expected 'k must be positive, got -5', got: %v", err)
 	}
@@ -168,13 +168,13 @@ func TestValidateK_NegativeK(t *testing.T) {
 
 func TestValidateK_KTooLarge(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 50, 1000, 50)
-	
+
 	err := validator.validateK(100)
-	
+
 	if err == nil {
 		t.Error("Expected error for k too large, got nil")
 	}
-	
+
 	expectedMsg := "k 100 exceeds maximum 50"
 	if err.Error() != expectedMsg {
 		t.Errorf("Expected '%s', got: %v", expectedMsg, err)
@@ -183,9 +183,9 @@ func TestValidateK_KTooLarge(t *testing.T) {
 
 func TestValidateVectorID_ValidID(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateVectorID("valid-vector-id_123")
-	
+
 	if err != nil {
 		t.Errorf("Expected no error for valid vector ID, got: %v", err)
 	}
@@ -193,13 +193,13 @@ func TestValidateVectorID_ValidID(t *testing.T) {
 
 func TestValidateVectorID_EmptyID(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateVectorID("")
-	
+
 	if err == nil {
 		t.Error("Expected error for empty vector ID, got nil")
 	}
-	
+
 	if err.Error() != "vector ID cannot be empty" {
 		t.Errorf("Expected 'vector ID cannot be empty', got: %v", err)
 	}
@@ -207,15 +207,15 @@ func TestValidateVectorID_EmptyID(t *testing.T) {
 
 func TestValidateVectorID_IDTooLong(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	// Create a very long ID (more than 128 characters)
 	longID := "a"
 	for i := 0; i < 130; i++ {
 		longID += "a"
 	}
-	
+
 	err := validator.ValidateVectorID(longID)
-	
+
 	if err == nil {
 		t.Error("Expected error for vector ID too long, got nil")
 	}
@@ -223,9 +223,9 @@ func TestValidateVectorID_IDTooLong(t *testing.T) {
 
 func TestValidateDistanceThreshold_ValidThreshold(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateDistanceThreshold(0.5)
-	
+
 	if err != nil {
 		t.Errorf("Expected no error for valid threshold, got: %v", err)
 	}
@@ -233,13 +233,13 @@ func TestValidateDistanceThreshold_ValidThreshold(t *testing.T) {
 
 func TestValidateDistanceThreshold_NegativeThreshold(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateDistanceThreshold(-0.1)
-	
+
 	if err == nil {
 		t.Error("Expected error for negative threshold, got nil")
 	}
-	
+
 	if err.Error() != "distance threshold cannot be negative" {
 		t.Errorf("Expected 'distance threshold cannot be negative', got: %v", err)
 	}
@@ -247,9 +247,9 @@ func TestValidateDistanceThreshold_NegativeThreshold(t *testing.T) {
 
 func TestValidateDistanceThreshold_ThresholdTooLarge(t *testing.T) {
 	validator := NewSearchRequestValidator(1000, 100, 1000, 50)
-	
+
 	err := validator.ValidateDistanceThreshold(1e7) // Too large
-	
+
 	if err == nil {
 		t.Error("Expected error for threshold too large, got nil")
 	}
@@ -257,28 +257,28 @@ func TestValidateDistanceThreshold_ThresholdTooLarge(t *testing.T) {
 
 func TestValidationErrors(t *testing.T) {
 	errors := &ValidationErrors{}
-	
+
 	if errors.HasErrors() {
 		t.Error("Expected HasErrors to return false for empty errors")
 	}
-	
+
 	errors.AddError("field1", "error message", "value1")
 	errors.AddError("field2", "another error", "value2")
-	
+
 	if !errors.HasErrors() {
 		t.Error("Expected HasErrors to return true after adding errors")
 	}
-	
+
 	if len(errors.GetErrors()) != 2 {
 		t.Errorf("Expected 2 errors, got %d", len(errors.GetErrors()))
 	}
-	
+
 	errorStr := errors.Error()
 	if errorStr == "" {
 		t.Error("Expected non-empty error string")
 	}
-	
-       if !strings.Contains(errorStr, "field1") || !strings.Contains(errorStr, "field2") {
-               t.Error("Expected error string to contain field names")
-       }
+
+	if !strings.Contains(errorStr, "field1") || !strings.Contains(errorStr, "field2") {
+		t.Error("Expected error string to contain field names")
+	}
 }

--- a/internal/service/health/endpoints.go
+++ b/internal/service/health/endpoints.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	
-	"vexdb/internal/config"
-	"vexdb/internal/errors"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
+
+	"vxdb/internal/config"
+	"vxdb/internal/errors"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
 )
 
 var (
@@ -38,12 +38,12 @@ type HealthCheck func(ctx context.Context) error
 
 // HealthCheckConfig represents health check configuration
 type HealthCheckConfig struct {
-	Name        string        `yaml:"name" json:"name"`
-	Enabled     bool          `yaml:"enabled" json:"enabled"`
-	Interval    time.Duration `yaml:"interval" json:"interval"`
-	Timeout     time.Duration `yaml:"timeout" json:"timeout"`
+	Name         string        `yaml:"name" json:"name"`
+	Enabled      bool          `yaml:"enabled" json:"enabled"`
+	Interval     time.Duration `yaml:"interval" json:"interval"`
+	Timeout      time.Duration `yaml:"timeout" json:"timeout"`
 	InitialDelay time.Duration `yaml:"initial_delay" json:"initial_delay"`
-	Critical    bool          `yaml:"critical" json:"critical"`
+	Critical     bool          `yaml:"critical" json:"critical"`
 }
 
 // HealthCheckResult represents the result of a health check
@@ -61,22 +61,22 @@ type HealthCheckResult struct {
 
 // HealthReport represents a comprehensive health report
 type HealthReport struct {
-	Status       HealthStatus         `json:"status"`
-	Timestamp    time.Time            `json:"timestamp"`
-	Version      string               `json:"version,omitempty"`
-	Uptime       time.Duration        `json:"uptime"`
-	Checks       map[string]HealthCheckResult `json:"checks"`
-	Summary      HealthSummary        `json:"summary"`
+	Status    HealthStatus                 `json:"status"`
+	Timestamp time.Time                    `json:"timestamp"`
+	Version   string                       `json:"version,omitempty"`
+	Uptime    time.Duration                `json:"uptime"`
+	Checks    map[string]HealthCheckResult `json:"checks"`
+	Summary   HealthSummary                `json:"summary"`
 }
 
 // HealthSummary represents a summary of health checks
 type HealthSummary struct {
-	Total      int `json:"total"`
-	Healthy    int `json:"healthy"`
-	Unhealthy  int `json:"unhealthy"`
-	Degraded   int `json:"degraded"`
-	Unknown    int `json:"unknown"`
-	Critical   int `json:"critical"`
+	Total     int `json:"total"`
+	Healthy   int `json:"healthy"`
+	Unhealthy int `json:"unhealthy"`
+	Degraded  int `json:"degraded"`
+	Unknown   int `json:"unknown"`
+	Critical  int `json:"critical"`
 }
 
 // HealthConfig represents the health check service configuration
@@ -95,44 +95,44 @@ type HealthConfig struct {
 // DefaultHealthConfig returns the default health check configuration
 func DefaultHealthConfig() *HealthConfig {
 	return &HealthConfig{
-		Enabled:        true,
-		Port:           8080,
-		Path:           "/health",
-		ReadTimeout:    5 * time.Second,
-		WriteTimeout:   5 * time.Second,
-		IdleTimeout:    60 * time.Second,
+		Enabled:      true,
+		Port:         8080,
+		Path:         "/health",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  60 * time.Second,
 		Checks: []HealthCheckConfig{
 			{
-				Name:        "storage",
-				Enabled:     true,
-				Interval:    30 * time.Second,
-				Timeout:     10 * time.Second,
+				Name:         "storage",
+				Enabled:      true,
+				Interval:     30 * time.Second,
+				Timeout:      10 * time.Second,
 				InitialDelay: 5 * time.Second,
-				Critical:    true,
+				Critical:     true,
 			},
 			{
-				Name:        "search",
-				Enabled:     true,
-				Interval:    30 * time.Second,
-				Timeout:     10 * time.Second,
+				Name:         "search",
+				Enabled:      true,
+				Interval:     30 * time.Second,
+				Timeout:      10 * time.Second,
 				InitialDelay: 5 * time.Second,
-				Critical:    true,
+				Critical:     true,
 			},
 			{
-				Name:        "memory",
-				Enabled:     true,
-				Interval:    60 * time.Second,
-				Timeout:     5 * time.Second,
+				Name:         "memory",
+				Enabled:      true,
+				Interval:     60 * time.Second,
+				Timeout:      5 * time.Second,
 				InitialDelay: 10 * time.Second,
-				Critical:    false,
+				Critical:     false,
 			},
 			{
-				Name:        "disk",
-				Enabled:     true,
-				Interval:    60 * time.Second,
-				Timeout:     5 * time.Second,
+				Name:         "disk",
+				Enabled:      true,
+				Interval:     60 * time.Second,
+				Timeout:      5 * time.Second,
 				InitialDelay: 10 * time.Second,
-				Critical:    false,
+				Critical:     false,
 			},
 		},
 		EnableDetailed: true,
@@ -142,37 +142,37 @@ func DefaultHealthConfig() *HealthConfig {
 
 // HealthEndpoints represents health check endpoints
 type HealthEndpoints struct {
-	config     *HealthConfig
-	logger     logging.Logger
-	metrics    *metrics.ServiceMetrics
-	
+	config  *HealthConfig
+	logger  logging.Logger
+	metrics *metrics.ServiceMetrics
+
 	// Health checks
-	checks     map[string]HealthCheck
-	results    map[string]HealthCheckResult
-	mu         sync.RWMutex
-	
+	checks  map[string]HealthCheck
+	results map[string]HealthCheckResult
+	mu      sync.RWMutex
+
 	// HTTP server
-	server     *http.Server
-	startTime  time.Time
-	
+	server    *http.Server
+	startTime time.Time
+
 	// Lifecycle
-	started    bool
-	stopped    bool
-	shutdown   chan struct{}
+	started  bool
+	stopped  bool
+	shutdown chan struct{}
 }
 
 // NewHealthEndpoints creates new health check endpoints
 func NewHealthEndpoints(cfg config.Config, logger logging.Logger, metrics *metrics.ServiceMetrics) (*HealthEndpoints, error) {
 	healthConfig := DefaultHealthConfig()
-	
+
 	// For now, use default config since we don't have a generic Get method
 	// TODO: Implement proper configuration extraction based on config type
-	
+
 	// Validate configuration
 	if err := validateHealthConfig(healthConfig); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidCheckConfig, err)
 	}
-	
+
 	endpoints := &HealthEndpoints{
 		config:    healthConfig,
 		logger:    logger,
@@ -182,16 +182,16 @@ func NewHealthEndpoints(cfg config.Config, logger logging.Logger, metrics *metri
 		startTime: time.Now(),
 		shutdown:  make(chan struct{}),
 	}
-	
+
 	// Initialize HTTP server
 	endpoints.initializeHTTPServer()
-	
+
 	endpoints.logger.Info("Created health endpoints",
 		zap.Bool("enabled", healthConfig.Enabled),
 		zap.Int("port", healthConfig.Port),
 		zap.String("path", healthConfig.Path),
 		zap.Int("checks_count", len(healthConfig.Checks)))
-	
+
 	return endpoints, nil
 }
 
@@ -200,23 +200,23 @@ func validateHealthConfig(cfg *HealthConfig) error {
 	if cfg.Port <= 0 || cfg.Port > 65535 {
 		return errors.New(errors.ErrorCodeInvalidArgument, "port must be between 1 and 65535")
 	}
-	
+
 	if cfg.Path == "" {
 		return errors.New(errors.ErrorCodeInvalidArgument, "path cannot be empty")
 	}
-	
+
 	if cfg.ReadTimeout <= 0 {
 		return errors.New(errors.ErrorCodeInvalidArgument, "read timeout must be positive")
 	}
-	
+
 	if cfg.WriteTimeout <= 0 {
 		return errors.New(errors.ErrorCodeInvalidArgument, "write timeout must be positive")
 	}
-	
+
 	if cfg.IdleTimeout <= 0 {
 		return errors.New(errors.ErrorCodeInvalidArgument, "idle timeout must be positive")
 	}
-	
+
 	for _, check := range cfg.Checks {
 		if check.Name == "" {
 			return errors.New(errors.ErrorCodeInvalidArgument, "check name cannot be empty")
@@ -231,20 +231,20 @@ func validateHealthConfig(cfg *HealthConfig) error {
 			return errors.New(errors.ErrorCodeInvalidArgument, "check initial delay must be non-negative")
 		}
 	}
-	
+
 	return nil
 }
 
 // initializeHTTPServer initializes the HTTP server
 func (h *HealthEndpoints) initializeHTTPServer() {
 	mux := http.NewServeMux()
-	
+
 	// Register health endpoints
 	mux.HandleFunc(h.config.Path, h.handleHealth)
 	mux.HandleFunc(h.config.Path+"/live", h.handleLiveness)
 	mux.HandleFunc(h.config.Path+"/ready", h.handleReadiness)
 	mux.HandleFunc(h.config.Path+"/detailed", h.handleDetailedHealth)
-	
+
 	h.server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", h.config.Port),
 		Handler:      mux,
@@ -258,11 +258,11 @@ func (h *HealthEndpoints) initializeHTTPServer() {
 func (h *HealthEndpoints) Start() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	if h.started {
 		return nil
 	}
-	
+
 	// Start HTTP server
 	go func() {
 		h.logger.Info("Starting health endpoints server", zap.Int("port", h.config.Port))
@@ -270,19 +270,19 @@ func (h *HealthEndpoints) Start() error {
 			h.logger.Error("Health endpoints server failed", zap.Error(err))
 		}
 	}()
-	
+
 	// Start health check runners
 	for _, checkConfig := range h.config.Checks {
 		if checkConfig.Enabled {
 			go h.runHealthCheck(checkConfig)
 		}
 	}
-	
+
 	h.started = true
 	h.stopped = false
-	
+
 	h.logger.Info("Started health endpoints")
-	
+
 	return nil
 }
 
@@ -290,31 +290,31 @@ func (h *HealthEndpoints) Start() error {
 func (h *HealthEndpoints) Stop() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	if h.stopped {
 		return nil
 	}
-	
+
 	if !h.started {
 		return nil
 	}
-	
+
 	// Signal shutdown
 	close(h.shutdown)
-	
+
 	// Shutdown HTTP server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	
+
 	if err := h.server.Shutdown(ctx); err != nil {
 		h.logger.Error("Failed to shutdown health endpoints server", zap.Error(err))
 	}
-	
+
 	h.stopped = true
 	h.started = false
-	
+
 	h.logger.Info("Stopped health endpoints")
-	
+
 	return nil
 }
 
@@ -322,7 +322,7 @@ func (h *HealthEndpoints) Stop() error {
 func (h *HealthEndpoints) IsRunning() bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	return h.started && !h.stopped
 }
 
@@ -330,13 +330,13 @@ func (h *HealthEndpoints) IsRunning() bool {
 func (h *HealthEndpoints) RegisterCheck(name string, check HealthCheck) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	if _, exists := h.checks[name]; exists {
 		return fmt.Errorf("%w: %s", ErrServiceNotRegistered, name)
 	}
-	
+
 	h.checks[name] = check
-	
+
 	// Initialize result
 	h.results[name] = HealthCheckResult{
 		Name:      name,
@@ -346,9 +346,9 @@ func (h *HealthEndpoints) RegisterCheck(name string, check HealthCheck) error {
 		Checks:    0,
 		Failures:  0,
 	}
-	
+
 	h.logger.Info("Registered health check", zap.String("name", name))
-	
+
 	return nil
 }
 
@@ -356,16 +356,16 @@ func (h *HealthEndpoints) RegisterCheck(name string, check HealthCheck) error {
 func (h *HealthEndpoints) UnregisterCheck(name string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	if _, exists := h.checks[name]; !exists {
 		return fmt.Errorf("%w: %s", ErrServiceNotRegistered, name)
 	}
-	
+
 	delete(h.checks, name)
 	delete(h.results, name)
-	
+
 	h.logger.Info("Unregistered health check", zap.String("name", name))
-	
+
 	return nil
 }
 
@@ -373,7 +373,7 @@ func (h *HealthEndpoints) UnregisterCheck(name string) error {
 func (h *HealthEndpoints) GetCheckResult(name string) (HealthCheckResult, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	result, exists := h.results[name]
 	return result, exists
 }
@@ -382,22 +382,22 @@ func (h *HealthEndpoints) GetCheckResult(name string) (HealthCheckResult, bool) 
 func (h *HealthEndpoints) GetHealthReport() *HealthReport {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	report := &HealthReport{
 		Timestamp: time.Now(),
 		Version:   "1.0.0",
 		Uptime:    time.Since(h.startTime),
 		Checks:    make(map[string]HealthCheckResult),
 	}
-	
+
 	// Copy results
 	for name, result := range h.results {
 		report.Checks[name] = result
 	}
-	
+
 	// Calculate overall status and summary
 	report.Status, report.Summary = h.calculateHealthStatus(report.Checks)
-	
+
 	return report
 }
 
@@ -405,12 +405,12 @@ func (h *HealthEndpoints) GetHealthReport() *HealthReport {
 func (h *HealthEndpoints) IsHealthy(service string) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	result, exists := h.results[service]
 	if !exists {
 		return false
 	}
-	
+
 	return result.Status == StatusHealthy
 }
 
@@ -418,7 +418,7 @@ func (h *HealthEndpoints) IsHealthy(service string) bool {
 func (h *HealthEndpoints) GetConfig() *HealthConfig {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	// Return a copy of config
 	config := *h.config
 	return &config
@@ -428,19 +428,19 @@ func (h *HealthEndpoints) GetConfig() *HealthConfig {
 func (h *HealthEndpoints) UpdateConfig(config *HealthConfig) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	// Validate new configuration
 	if err := validateHealthConfig(config); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidCheckConfig, err)
 	}
-	
+
 	h.config = config
-	
+
 	// Reinitialize HTTP server
 	h.initializeHTTPServer()
-	
+
 	h.logger.Info("Updated health endpoints configuration", zap.Any("config", config))
-	
+
 	return nil
 }
 
@@ -448,12 +448,12 @@ func (h *HealthEndpoints) UpdateConfig(config *HealthConfig) error {
 func (h *HealthEndpoints) Validate() error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	// Validate configuration
 	if err := validateHealthConfig(h.config); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -461,10 +461,10 @@ func (h *HealthEndpoints) Validate() error {
 func (h *HealthEndpoints) runHealthCheck(config HealthCheckConfig) {
 	// Wait for initial delay
 	time.Sleep(config.InitialDelay)
-	
+
 	ticker := time.NewTicker(config.Interval)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-ticker.C:
@@ -480,42 +480,42 @@ func (h *HealthEndpoints) executeHealthCheck(config HealthCheckConfig) {
 	h.mu.RLock()
 	check, exists := h.checks[config.Name]
 	h.mu.RUnlock()
-	
+
 	if !exists {
 		return
 	}
-	
+
 	start := time.Now()
-	
+
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()
-	
+
 	// Execute health check
 	err := check(ctx)
 	duration := time.Since(start)
-	
+
 	// Update result
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	result, exists := h.results[config.Name]
 	if !exists {
 		result = HealthCheckResult{
 			Name: config.Name,
 		}
 	}
-	
+
 	result.Duration = duration
 	result.Timestamp = time.Now()
 	result.LastCheck = time.Now()
 	result.Checks++
-	
+
 	if err != nil {
 		result.Status = StatusUnhealthy
 		result.Error = err.Error()
 		result.Failures++
-		
+
 		h.logger.Error("Health check failed",
 			zap.String("name", config.Name),
 			zap.Duration("duration", duration),
@@ -523,14 +523,14 @@ func (h *HealthEndpoints) executeHealthCheck(config HealthCheckConfig) {
 	} else {
 		result.Status = StatusHealthy
 		result.Error = ""
-		
+
 		h.logger.Debug("Health check passed",
 			zap.String("name", config.Name),
 			zap.Duration("duration", duration))
 	}
-	
+
 	h.results[config.Name] = result
-	
+
 	// Update metrics if enabled
 	if h.config.EnableMetrics && h.metrics != nil {
 		if err != nil {
@@ -544,10 +544,10 @@ func (h *HealthEndpoints) executeHealthCheck(config HealthCheckConfig) {
 // calculateHealthStatus calculates overall health status
 func (h *HealthEndpoints) calculateHealthStatus(checks map[string]HealthCheckResult) (HealthStatus, HealthSummary) {
 	summary := HealthSummary{}
-	
+
 	for _, check := range checks {
 		summary.Total++
-		
+
 		switch check.Status {
 		case StatusHealthy:
 			summary.Healthy++
@@ -558,7 +558,7 @@ func (h *HealthEndpoints) calculateHealthStatus(checks map[string]HealthCheckRes
 		case StatusUnknown:
 			summary.Unknown++
 		}
-		
+
 		// Count critical failures
 		if check.Status == StatusUnhealthy {
 			// Check if this is a critical service
@@ -570,7 +570,7 @@ func (h *HealthEndpoints) calculateHealthStatus(checks map[string]HealthCheckRes
 			}
 		}
 	}
-	
+
 	// Determine overall status
 	var status HealthStatus
 	if summary.Critical > 0 {
@@ -582,28 +582,28 @@ func (h *HealthEndpoints) calculateHealthStatus(checks map[string]HealthCheckRes
 	} else {
 		status = StatusUnknown
 	}
-	
+
 	return status, summary
 }
 
 // HTTP handlers
 func (h *HealthEndpoints) handleHealth(w http.ResponseWriter, r *http.Request) {
 	report := h.GetHealthReport()
-	
+
 	status := http.StatusOK
 	if report.Status == StatusUnhealthy {
 		status = http.StatusServiceUnavailable
 	} else if report.Status == StatusDegraded {
 		status = http.StatusPartialContent
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	
+
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status": report.Status,
+		"status":    report.Status,
 		"timestamp": report.Timestamp,
-		"uptime": report.Uptime.String(),
+		"uptime":    report.Uptime.String(),
 	})
 }
 
@@ -624,20 +624,20 @@ func (h *HealthEndpoints) handleLiveness(w http.ResponseWriter, r *http.Request)
 
 func (h *HealthEndpoints) handleReadiness(w http.ResponseWriter, r *http.Request) {
 	report := h.GetHealthReport()
-	
+
 	status := http.StatusOK
 	if report.Status == StatusUnhealthy {
 		status = http.StatusServiceUnavailable
 	} else if report.Status == StatusDegraded {
 		status = http.StatusPartialContent
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	
+
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status": report.Status,
-		"ready": report.Status == StatusHealthy,
+		"status":    report.Status,
+		"ready":     report.Status == StatusHealthy,
 		"timestamp": report.Timestamp,
 	})
 }
@@ -647,19 +647,19 @@ func (h *HealthEndpoints) handleDetailedHealth(w http.ResponseWriter, r *http.Re
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	
+
 	report := h.GetHealthReport()
-	
+
 	status := http.StatusOK
 	if report.Status == StatusUnhealthy {
 		status = http.StatusServiceUnavailable
 	} else if report.Status == StatusDegraded {
 		status = http.StatusPartialContent
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	
+
 	json.NewEncoder(w).Encode(report)
 }
 

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"vexdb/internal/types"
-	pb "vexdb/proto"
+	"vxdb/internal/types"
+	pb "vxdb/proto"
 )
 
 // StorageService defines the interface for vector storage operations
@@ -13,22 +13,22 @@ type StorageService interface {
 	// Insert operations
 	InsertVector(ctx context.Context, vector *types.Vector) error
 	InsertBatch(ctx context.Context, vectors []*types.Vector) error
-	
+
 	// Search operations
 	Search(ctx context.Context, query *types.Vector, k int, filter map[string]string) ([]*types.SearchResult, error)
-	
+
 	// Delete operations
 	DeleteVector(ctx context.Context, vectorID string) error
 	DeleteByMetadata(ctx context.Context, filter map[string]string) (int64, error)
-	
+
 	// Cluster management
 	GetClusterInfo(ctx context.Context, clusterID string) (*types.ClusterInfo, error)
 	GetClusterStatus(ctx context.Context) (*types.ClusterStatus, error)
-	
+
 	// Health and metrics
 	HealthCheck(ctx context.Context, detailed bool) (*types.HealthStatus, error)
 	GetMetrics(ctx context.Context, metricType, clusterID, nodeID string) (map[string]float64, error)
-	
+
 	// Configuration
 	UpdateConfig(ctx context.Context, config map[string]string) error
 	GetConfig(ctx context.Context) (map[string]string, error)
@@ -39,15 +39,15 @@ type InsertService interface {
 	// Insert operations
 	InsertVector(ctx context.Context, vector *types.Vector) error
 	InsertBatch(ctx context.Context, vectors []*types.Vector) error
-	
+
 	// Routing and cluster management
 	GetClusterForVector(ctx context.Context, vector *types.Vector) (*types.ClusterInfo, error)
 	GetClusterStatus(ctx context.Context) (*types.ClusterStatus, error)
-	
+
 	// Health and metrics
 	HealthCheck(ctx context.Context, detailed bool) (*types.HealthStatus, error)
 	GetMetrics(ctx context.Context, metricType, clusterID, nodeID string) (map[string]float64, error)
-	
+
 	// Configuration
 	UpdateConfig(ctx context.Context, config map[string]string) error
 	GetConfig(ctx context.Context) (map[string]string, error)
@@ -58,15 +58,15 @@ type SearchService interface {
 	// Search operations
 	Search(ctx context.Context, query *types.Vector, k int, filter map[string]string) ([]*types.SearchResult, error)
 	MultiClusterSearch(ctx context.Context, query *types.Vector, k int, clusterIDs []string, filter map[string]string) ([]*types.SearchResult, error)
-	
+
 	// Cluster management
 	GetClusterInfo(ctx context.Context, clusterID string) (*types.ClusterInfo, error)
 	GetClusterStatus(ctx context.Context) (*types.ClusterStatus, error)
-	
+
 	// Health and metrics
 	HealthCheck(ctx context.Context, detailed bool) (*types.HealthStatus, error)
 	GetMetrics(ctx context.Context, metricType, clusterID, nodeID string) (map[string]float64, error)
-	
+
 	// Configuration
 	UpdateConfig(ctx context.Context, config map[string]string) error
 	GetConfig(ctx context.Context) (map[string]string, error)
@@ -78,21 +78,21 @@ type AdminService interface {
 	AddNode(ctx context.Context, node *types.NodeInfo) (*types.NodeInfo, error)
 	RemoveNode(ctx context.Context, nodeID string) error
 	UpdateNode(ctx context.Context, node *types.NodeInfo) (*types.NodeInfo, error)
-	
+
 	// Cluster operations
 	CreateCluster(ctx context.Context, cluster *types.ClusterInfo) (*types.ClusterInfo, error)
 	DeleteCluster(ctx context.Context, clusterID string) error
 	UpdateCluster(ctx context.Context, cluster *types.ClusterInfo) (*types.ClusterInfo, error)
-	
+
 	// System operations
 	BackupSystem(ctx context.Context) error
 	RestoreSystem(ctx context.Context) error
 	CompactStorage(ctx context.Context) error
-	
+
 	// Health and metrics
 	HealthCheck(ctx context.Context, detailed bool) (*types.HealthStatus, error)
 	GetMetrics(ctx context.Context, metricType, clusterID, nodeID string) (map[string]float64, error)
-	
+
 	// Configuration
 	UpdateConfig(ctx context.Context, config map[string]string) error
 	GetConfig(ctx context.Context) (map[string]string, error)
@@ -124,15 +124,15 @@ type Service interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Reload(ctx context.Context) error
-	
+
 	// Health and status
 	HealthCheck(ctx context.Context) bool
 	GetStatus(ctx context.Context) map[string]interface{}
-	
+
 	// Configuration
 	GetConfig() *types.Config
 	UpdateConfig(config *types.Config) error
-	
+
 	// Metrics
 	GetMetrics() map[string]interface{}
 }
@@ -145,18 +145,18 @@ type ClusterManager interface {
 	UpdateNode(node *types.NodeInfo) error
 	GetNode(nodeID string) (*types.NodeInfo, error)
 	ListNodes() ([]*types.NodeInfo, error)
-	
+
 	// Cluster management
 	CreateCluster(cluster *types.ClusterInfo) error
 	DeleteCluster(clusterID string) error
 	UpdateCluster(cluster *types.ClusterInfo) error
 	GetCluster(clusterID string) (*types.ClusterInfo, error)
 	ListClusters() ([]*types.ClusterInfo, error)
-	
+
 	// Health monitoring
 	CheckNodeHealth(nodeID string) (*types.HealthStatus, error)
 	CheckClusterHealth(clusterID string) (*types.HealthStatus, error)
-	
+
 	// Routing
 	GetNodesForCluster(clusterID string) ([]*types.NodeInfo, error)
 	GetClusterForVector(vector *types.Vector) (*types.ClusterInfo, error)
@@ -169,20 +169,20 @@ type VectorStorage interface {
 	InsertBatch(vectors []*types.Vector) error
 	Get(vectorID string) (*types.Vector, error)
 	Delete(vectorID string) error
-	
+
 	// Search operations
 	Search(query *types.Vector, k int, filter map[string]string) ([]*types.SearchResult, error)
 	SearchInCluster(clusterID string, query *types.Vector, k int, filter map[string]string) ([]*types.SearchResult, error)
-	
+
 	// Cluster operations
 	GetClusterVectors(clusterID string) ([]*types.Vector, error)
 	GetClusterCount(clusterID string) (int64, error)
-	
+
 	// Maintenance
 	Compact() error
 	Backup() error
 	Restore() error
-	
+
 	// Statistics
 	GetStats() map[string]interface{}
 }
@@ -192,15 +192,15 @@ type ProtocolAdapter interface {
 	// Lifecycle
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	
+
 	// Protocol handling
 	HandleRequest(ctx context.Context, request interface{}) (interface{}, error)
 	ValidateRequest(request interface{}) error
-	
+
 	// Configuration
 	GetConfig() map[string]interface{}
 	UpdateConfig(config map[string]interface{}) error
-	
+
 	// Metrics
 	GetMetrics() map[string]interface{}
 }
@@ -210,15 +210,15 @@ type Router interface {
 	// Routing
 	RouteVector(vector *types.Vector) ([]*types.NodeInfo, error)
 	RouteToCluster(clusterID string, vector *types.Vector) ([]*types.NodeInfo, error)
-	
+
 	// Replication
 	ReplicateVector(ctx context.Context, vector *types.Vector, nodes []*types.NodeInfo) error
 	ReplicateBatch(ctx context.Context, vectors []*types.Vector, nodes []*types.NodeInfo) error
-	
+
 	// Load balancing
 	GetLeastLoadedNode(nodes []*types.NodeInfo) (*types.NodeInfo, error)
 	GetNodesForReplication(clusterID string, replicationFactor int) ([]*types.NodeInfo, error)
-	
+
 	// Health monitoring
 	CheckNodeHealth(node *types.NodeInfo) bool
 	GetHealthyNodes(clusterID string) ([]*types.NodeInfo, error)
@@ -229,15 +229,15 @@ type QueryPlanner interface {
 	// Query planning
 	PlanSearch(query *types.Vector, k int, filter map[string]string) (*types.QueryPlan, error)
 	PlanMultiClusterSearch(query *types.Vector, k int, clusterIDs []string, filter map[string]string) (*types.QueryPlan, error)
-	
+
 	// Query optimization
 	OptimizeQuery(plan *types.QueryPlan) (*types.QueryPlan, error)
 	EstimateQueryCost(plan *types.QueryPlan) (float64, error)
-	
+
 	// Query execution
 	ExecutePlan(ctx context.Context, plan *types.QueryPlan) ([]*types.SearchResult, error)
 	CancelQuery(ctx context.Context, queryID string) error
-	
+
 	// Query statistics
 	GetQueryStats(queryID string) (*types.QueryStats, error)
 	GetQueryHistory() ([]*types.QueryStats, error)
@@ -248,14 +248,14 @@ type ResultMerger interface {
 	// Result merging
 	MergeResults(results [][]*types.SearchResult, k int) ([]*types.SearchResult, error)
 	MergeMultiClusterResults(clusterResults map[string][]*types.SearchResult, k int) ([]*types.SearchResult, error)
-	
+
 	// Result ranking
 	RankResults(results []*types.SearchResult) ([]*types.SearchResult, error)
 	FilterResults(results []*types.SearchResult, filter map[string]string) ([]*types.SearchResult, error)
-	
+
 	// Deduplication
 	DeduplicateResults(results []*types.SearchResult) ([]*types.SearchResult, error)
-	
+
 	// Result aggregation
 	AggregateResults(results []*types.SearchResult) (*types.AggregatedResult, error)
 }
@@ -267,11 +267,11 @@ type HealthChecker interface {
 	CheckNodeHealth(nodeID string) (*types.HealthStatus, error)
 	CheckClusterHealth(clusterID string) (*types.HealthStatus, error)
 	CheckSystemHealth() (*types.SystemHealth, error)
-	
+
 	// Health monitoring
 	StartHealthMonitoring(ctx context.Context, interval time.Duration) error
 	StopHealthMonitoring() error
-	
+
 	// Health status
 	GetHealthStatus() map[string]*types.HealthStatus
 	GetHealthHistory(serviceID string) ([]*types.HealthStatus, error)
@@ -284,15 +284,15 @@ type MetricsCollector interface {
 	CollectServiceMetrics(serviceID string) (map[string]interface{}, error)
 	CollectNodeMetrics(nodeID string) (map[string]interface{}, error)
 	CollectClusterMetrics(clusterID string) (map[string]interface{}, error)
-	
+
 	// Metrics aggregation
 	AggregateMetrics(metrics []map[string]interface{}) (map[string]interface{}, error)
 	GetAggregatedMetrics(timeRange time.Duration) (map[string]interface{}, error)
-	
+
 	// Metrics export
 	ExportMetrics(format string) ([]byte, error)
 	ExportMetricsToPrometheus() ([]byte, error)
-	
+
 	// Metrics history
 	GetMetricsHistory(metricName string, timeRange time.Duration) ([]*types.MetricPoint, error)
 }
@@ -303,15 +303,15 @@ type ConfigManager interface {
 	GetConfig() (*types.Config, error)
 	UpdateConfig(config *types.Config) error
 	ReloadConfig() error
-	
+
 	// Configuration validation
 	ValidateConfig(config *types.Config) error
 	GetConfigSchema() map[string]interface{}
-	
+
 	// Configuration persistence
 	SaveConfig(config *types.Config) error
 	LoadConfig() (*types.Config, error)
-	
+
 	// Configuration versioning
 	GetConfigVersions() ([]*types.ConfigVersion, error)
 	RollbackConfig(version string) error
@@ -325,14 +325,14 @@ type Logger interface {
 	Warn(msg string, fields ...interface{})
 	Error(msg string, fields ...interface{})
 	Fatal(msg string, fields ...interface{})
-	
+
 	// Contextual logging
 	With(fields ...interface{}) Logger
 	WithContext(ctx context.Context) Logger
-	
+
 	// Performance logging
 	Measure(operation string, duration time.Duration, fields ...interface{})
-	
+
 	// Structured logging
 	Structured(level string, msg string, fields map[string]interface{})
 }

--- a/internal/service/metrics/collector.go
+++ b/internal/service/metrics/collector.go
@@ -8,9 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/errors"
-	"vexdb/internal/logging"
+	"vxdb/internal/config"
+	"vxdb/internal/errors"
+	"vxdb/internal/logging"
 )
 
 var (
@@ -21,21 +21,21 @@ var (
 
 // MetricsConfig represents the metrics collection configuration
 type MetricsConfig struct {
-	Enabled           bool          `yaml:"enabled" json:"enabled"`
-	Port              int           `yaml:"port" json:"port"`
-	Path              string        `yaml:"path" json:"path"`
-	Namespace         string        `yaml:"namespace" json:"namespace"`
-	Subsystem         string        `yaml:"subsystem" json:"subsystem"`
-	EnableHistograms  bool          `yaml:"enable_histograms" json:"enable_histograms"`
-	HistogramBuckets  []float64     `yaml:"histogram_buckets" json:"histogram_buckets"`
-	EnableGauges      bool          `yaml:"enable_gauges" json:"enable_gauges"`
-	EnableCounters    bool          `yaml:"enable_counters" json:"enable_counters"`
-	EnableSummaries   bool          `yaml:"enable_summaries" json:"enable_summaries"`
-	CollectInterval   time.Duration `yaml:"collect_interval" json:"collect_interval"`
-	EnableRuntime     bool          `yaml:"enable_runtime" json:"enable_runtime"`
-	EnableProcess     bool          `yaml:"enable_process" json:"enable_process"`
-	EnableGoMetrics   bool          `yaml:"enable_go_metrics" json:"enable_go_metrics"`
-	EnableCustom      bool          `yaml:"enable_custom" json:"enable_custom"`
+	Enabled          bool          `yaml:"enabled" json:"enabled"`
+	Port             int           `yaml:"port" json:"port"`
+	Path             string        `yaml:"path" json:"path"`
+	Namespace        string        `yaml:"namespace" json:"namespace"`
+	Subsystem        string        `yaml:"subsystem" json:"subsystem"`
+	EnableHistograms bool          `yaml:"enable_histograms" json:"enable_histograms"`
+	HistogramBuckets []float64     `yaml:"histogram_buckets" json:"histogram_buckets"`
+	EnableGauges     bool          `yaml:"enable_gauges" json:"enable_gauges"`
+	EnableCounters   bool          `yaml:"enable_counters" json:"enable_counters"`
+	EnableSummaries  bool          `yaml:"enable_summaries" json:"enable_summaries"`
+	CollectInterval  time.Duration `yaml:"collect_interval" json:"collect_interval"`
+	EnableRuntime    bool          `yaml:"enable_runtime" json:"enable_runtime"`
+	EnableProcess    bool          `yaml:"enable_process" json:"enable_process"`
+	EnableGoMetrics  bool          `yaml:"enable_go_metrics" json:"enable_go_metrics"`
+	EnableCustom     bool          `yaml:"enable_custom" json:"enable_custom"`
 }
 
 // DefaultMetricsConfig returns the default metrics configuration
@@ -44,7 +44,7 @@ func DefaultMetricsConfig() *MetricsConfig {
 		Enabled:          true,
 		Port:             9090,
 		Path:             "/metrics",
-		Namespace:        "vexdb",
+		Namespace:        "vxdb",
 		Subsystem:        "storage",
 		EnableHistograms: true,
 		HistogramBuckets: []float64{0.001, 0.01, 0.1, 1, 10, 100},
@@ -61,16 +61,16 @@ func DefaultMetricsConfig() *MetricsConfig {
 
 // MetricsCollector represents a metrics collector
 type MetricsCollector struct {
-	config     *MetricsConfig
-	logger     logging.Logger
-	
+	config *MetricsConfig
+	logger logging.Logger
+
 	// Prometheus registry
-	registry   *prometheus.Registry
-	
+	registry *prometheus.Registry
+
 	// Custom metrics
 	customMetrics map[string]prometheus.Collector
-	mu           sync.RWMutex
-	
+	mu            sync.RWMutex
+
 	// Collection state
 	started     bool
 	stopped     bool
@@ -80,83 +80,83 @@ type MetricsCollector struct {
 // StorageMetrics represents storage-specific metrics
 type StorageMetrics struct {
 	// Vector operations
-	VectorInserts     prometheus.Counter
-	VectorUpdates     prometheus.Counter
-	VectorDeletes     prometheus.Counter
-	VectorReads       prometheus.Counter
-	VectorSearches    prometheus.Counter
-	
+	VectorInserts  prometheus.Counter
+	VectorUpdates  prometheus.Counter
+	VectorDeletes  prometheus.Counter
+	VectorReads    prometheus.Counter
+	VectorSearches prometheus.Counter
+
 	// Storage operations
-	SegmentCreates    prometheus.Counter
-	SegmentReads      prometheus.Counter
-	SegmentWrites     prometheus.Counter
-	SegmentDeletes    prometheus.Counter
+	SegmentCreates     prometheus.Counter
+	SegmentReads       prometheus.Counter
+	SegmentWrites      prometheus.Counter
+	SegmentDeletes     prometheus.Counter
 	SegmentCompactions prometheus.Counter
-	
+
 	// Buffer operations
-	BufferFlushes     prometheus.Counter
-	BufferEvictions   prometheus.Counter
-	BufferHits        prometheus.Counter
-	BufferMisses      prometheus.Counter
-	BufferOperations  *prometheus.CounterVec
-	
+	BufferFlushes    prometheus.Counter
+	BufferEvictions  prometheus.Counter
+	BufferHits       prometheus.Counter
+	BufferMisses     prometheus.Counter
+	BufferOperations *prometheus.CounterVec
+
 	// Search operations
-	SearchOperations  prometheus.Counter
-	SearchErrors      *prometheus.CounterVec
-	SearchLatency     prometheus.Observer
+	SearchOperations         prometheus.Counter
+	SearchErrors             *prometheus.CounterVec
+	SearchLatency            prometheus.Observer
 	ParallelSearchOperations prometheus.Counter
-	ParallelSearchLatency prometheus.Observer
-	
+	ParallelSearchLatency    prometheus.Observer
+
 	// Compression operations
 	CompressionOps    prometheus.Counter
 	CompressionErrors prometheus.Counter
 	CompressionRatio  prometheus.Observer
-	
+
 	// Storage size
-	StorageSize       prometheus.Gauge
-	VectorCount       prometheus.Gauge
-	SegmentCount      prometheus.Gauge
-	BufferSize        prometheus.Gauge
-	
+	StorageSize  prometheus.Gauge
+	VectorCount  prometheus.Gauge
+	SegmentCount prometheus.Gauge
+	BufferSize   prometheus.Gauge
+
 	// Performance
 	InsertLatency     prometheus.Observer
 	ReadLatency       prometheus.Observer
 	DeleteLatency     prometheus.Observer
 	FlushLatency      prometheus.Observer
 	CompactionLatency prometheus.Observer
-	
+
 	// Errors
-	Errors            *prometheus.CounterVec
+	Errors *prometheus.CounterVec
 }
 
 // ServiceMetrics represents service-specific metrics
 type ServiceMetrics struct {
 	// gRPC metrics
-	GRPCRequests      prometheus.Counter
-	GRPCErrors        prometheus.Counter
-	GRPCLatency       prometheus.Observer
-	GRPCConnections   prometheus.Gauge
-	
+	GRPCRequests    prometheus.Counter
+	GRPCErrors      prometheus.Counter
+	GRPCLatency     prometheus.Observer
+	GRPCConnections prometheus.Gauge
+
 	// HTTP metrics
-	HTTPRequests      *prometheus.CounterVec
-	HTTPErrors        *prometheus.CounterVec
-	HTTPLatency       *prometheus.HistogramVec
-	HTTPConnections   prometheus.Gauge
-	
+	HTTPRequests    *prometheus.CounterVec
+	HTTPErrors      *prometheus.CounterVec
+	HTTPLatency     *prometheus.HistogramVec
+	HTTPConnections prometheus.Gauge
+
 	// Health check metrics
-	HealthCheckErrors prometheus.Counter
+	HealthCheckErrors  prometheus.Counter
 	HealthCheckLatency prometheus.Observer
-	
+
 	// Service metrics
-	ServiceUptime     prometheus.Gauge
-	ServiceVersion    *prometheus.GaugeVec
-	ServiceErrors     *prometheus.CounterVec
+	ServiceUptime  prometheus.Gauge
+	ServiceVersion *prometheus.GaugeVec
+	ServiceErrors  *prometheus.CounterVec
 }
 
 // NewMetricsCollector creates a new metrics collector
 func NewMetricsCollector(cfg config.Config, logger logging.Logger) (*MetricsCollector, error) {
 	metricsConfig := DefaultMetricsConfig()
-	
+
 	if cfg != nil {
 		if metricsCfg, ok := cfg.Get("metrics"); ok {
 			if cfgMap, ok := metricsCfg.(map[string]interface{}); ok {
@@ -215,12 +215,12 @@ func NewMetricsCollector(cfg config.Config, logger logging.Logger) (*MetricsColl
 			}
 		}
 	}
-	
+
 	// Validate configuration
 	if err := validateMetricsConfig(metricsConfig); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidMetricsConfig, err)
 	}
-	
+
 	collector := &MetricsCollector{
 		config:        metricsConfig,
 		logger:        logger,
@@ -228,19 +228,19 @@ func NewMetricsCollector(cfg config.Config, logger logging.Logger) (*MetricsColl
 		customMetrics: make(map[string]prometheus.Collector),
 		collectDone:   make(chan struct{}),
 	}
-	
+
 	// Initialize default metrics
 	if err := collector.initializeDefaultMetrics(); err != nil {
 		return nil, fmt.Errorf("failed to initialize default metrics: %w", err)
 	}
-	
+
 	collector.logger.Info("Created metrics collector",
 		zap.Bool("enabled", metricsConfig.Enabled),
 		zap.Int("port", metricsConfig.Port),
 		zap.String("path", metricsConfig.Path),
 		zap.String("namespace", metricsConfig.Namespace),
 		zap.String("subsystem", metricsConfig.Subsystem))
-	
+
 	return collector, nil
 }
 
@@ -249,25 +249,25 @@ func validateMetricsConfig(cfg *MetricsConfig) error {
 	if cfg.Port <= 0 || cfg.Port > 65535 {
 		return errors.New(errors.ErrorCodeConfigInvalid, "port must be between 1 and 65535")
 	}
-	
+
 	if cfg.Path == "" {
 		return errors.New(errors.ErrorCodeConfigInvalid, "path cannot be empty")
 	}
-	
+
 	if cfg.Namespace == "" {
 		return errors.New(errors.ErrorCodeConfigInvalid, "namespace cannot be empty")
 	}
-	
+
 	if cfg.CollectInterval <= 0 {
 		return errors.New(errors.ErrorCodeConfigInvalid, "collect interval must be positive")
 	}
-	
+
 	for _, bucket := range cfg.HistogramBuckets {
 		if bucket <= 0 {
 			return errors.New(errors.ErrorCodeConfigInvalid, "histogram buckets must be positive")
 		}
 	}
-	
+
 	return nil
 }
 
@@ -276,20 +276,20 @@ func (m *MetricsCollector) initializeDefaultMetrics() error {
 	if !m.config.Enabled {
 		return nil
 	}
-	
+
 	// Register default collectors
 	if m.config.EnableRuntime {
 		m.registry.MustRegister(prometheus.NewGoCollector())
 	}
-	
+
 	if m.config.EnableProcess {
 		m.registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	}
-	
+
 	if m.config.EnableGoMetrics {
 		m.registry.MustRegister(prometheus.NewGoCollector())
 	}
-	
+
 	return nil
 }
 
@@ -297,24 +297,24 @@ func (m *MetricsCollector) initializeDefaultMetrics() error {
 func (m *MetricsCollector) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.started {
 		return nil
 	}
-	
+
 	if !m.config.Enabled {
 		m.logger.Info("Metrics collection is disabled")
 		return nil
 	}
-	
+
 	// Start collection goroutine
 	go m.collectMetrics()
-	
+
 	m.started = true
 	m.stopped = false
-	
+
 	m.logger.Info("Started metrics collector")
-	
+
 	return nil
 }
 
@@ -322,23 +322,23 @@ func (m *MetricsCollector) Start() error {
 func (m *MetricsCollector) Stop() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.stopped {
 		return nil
 	}
-	
+
 	if !m.started {
 		return ErrCollectorNotRunning
 	}
-	
+
 	// Signal collection to stop
 	close(m.collectDone)
-	
+
 	m.stopped = true
 	m.started = false
-	
+
 	m.logger.Info("Stopped metrics collector")
-	
+
 	return nil
 }
 
@@ -346,7 +346,7 @@ func (m *MetricsCollector) Stop() error {
 func (m *MetricsCollector) IsRunning() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	return m.started && !m.stopped
 }
 
@@ -354,7 +354,7 @@ func (m *MetricsCollector) IsRunning() bool {
 func (m *MetricsCollector) GetRegistry() *prometheus.Registry {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	return m.registry
 }
 
@@ -362,7 +362,7 @@ func (m *MetricsCollector) GetRegistry() *prometheus.Registry {
 func (m *MetricsCollector) GetConfig() *MetricsConfig {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	// Return a copy of config
 	config := *m.config
 	return &config
@@ -372,16 +372,16 @@ func (m *MetricsCollector) GetConfig() *MetricsConfig {
 func (m *MetricsCollector) UpdateConfig(config *MetricsConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	// Validate new configuration
 	if err := validateMetricsConfig(config); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidMetricsConfig, err)
 	}
-	
+
 	m.config = config
-	
+
 	m.logger.Info("Updated metrics collector configuration", zap.Any("config", config))
-	
+
 	return nil
 }
 
@@ -389,28 +389,28 @@ func (m *MetricsCollector) UpdateConfig(config *MetricsConfig) error {
 func (m *MetricsCollector) RegisterCustomMetric(name string, metric prometheus.Collector) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if !m.config.Enabled {
 		return ErrMetricsNotEnabled
 	}
-	
+
 	if !m.config.EnableCustom {
 		return errors.New(errors.ErrorCodeInvalidArgument, "custom metrics are disabled")
 	}
-	
+
 	if _, exists := m.customMetrics[name]; exists {
 		return fmt.Errorf("metric %s is already registered", name)
 	}
-	
+
 	// Register metric
 	if err := m.registry.Register(metric); err != nil {
 		return fmt.Errorf("failed to register metric %s: %w", name, err)
 	}
-	
+
 	m.customMetrics[name] = metric
-	
+
 	m.logger.Info("Registered custom metric", zap.String("name", name))
-	
+
 	return nil
 }
 
@@ -418,22 +418,22 @@ func (m *MetricsCollector) RegisterCustomMetric(name string, metric prometheus.C
 func (m *MetricsCollector) UnregisterCustomMetric(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if !m.config.Enabled {
 		return ErrMetricsNotEnabled
 	}
-	
+
 	metric, exists := m.customMetrics[name]
 	if !exists {
 		return fmt.Errorf("metric %s is not registered", name)
 	}
-	
+
 	// Unregister metric
 	m.registry.Unregister(metric)
 	delete(m.customMetrics, name)
-	
+
 	m.logger.Info("Unregistered custom metric", zap.String("name", name))
-	
+
 	return nil
 }
 
@@ -441,12 +441,12 @@ func (m *MetricsCollector) UnregisterCustomMetric(name string) error {
 func (m *MetricsCollector) GetCustomMetrics() map[string]prometheus.Collector {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	metrics := make(map[string]prometheus.Collector)
 	for name, metric := range m.customMetrics {
 		metrics[name] = metric
 	}
-	
+
 	return metrics
 }
 
@@ -455,7 +455,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 	if !m.config.Enabled {
 		return nil, ErrMetricsNotEnabled
 	}
-	
+
 	metrics := &StorageMetrics{
 		// Vector operations
 		VectorInserts: promauto.NewCounterVec(prometheus.CounterOpts{
@@ -464,35 +464,35 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Name:      "vector_inserts_total",
 			Help:      "Total number of vector insert operations",
 		}, []string{"operation"}).WithLabelValues("insert"),
-		
+
 		VectorUpdates: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "vector_updates_total",
 			Help:      "Total number of vector update operations",
 		}, []string{"operation"}).WithLabelValues("update"),
-		
+
 		VectorDeletes: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "vector_deletes_total",
 			Help:      "Total number of vector delete operations",
 		}, []string{"operation"}).WithLabelValues("delete"),
-		
+
 		VectorReads: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "vector_reads_total",
 			Help:      "Total number of vector read operations",
 		}, []string{"operation"}).WithLabelValues("read"),
-		
+
 		VectorSearches: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "vector_searches_total",
 			Help:      "Total number of vector search operations",
 		}, []string{"operation"}).WithLabelValues("search"),
-		
+
 		// Storage operations
 		SegmentCreates: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -500,35 +500,35 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Name:      "segment_creates_total",
 			Help:      "Total number of segment create operations",
 		}, []string{"operation"}).WithLabelValues("create"),
-		
+
 		SegmentReads: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "segment_reads_total",
 			Help:      "Total number of segment read operations",
 		}, []string{"operation"}).WithLabelValues("read"),
-		
+
 		SegmentWrites: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "segment_writes_total",
 			Help:      "Total number of segment write operations",
 		}, []string{"operation"}).WithLabelValues("write"),
-		
+
 		SegmentDeletes: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "segment_deletes_total",
 			Help:      "Total number of segment delete operations",
 		}, []string{"operation"}).WithLabelValues("delete"),
-		
+
 		SegmentCompactions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "segment_compactions_total",
 			Help:      "Total number of segment compaction operations",
 		}, []string{"operation"}).WithLabelValues("compact"),
-		
+
 		// Buffer operations
 		BufferFlushes: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -536,35 +536,35 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Name:      "buffer_flushes_total",
 			Help:      "Total number of buffer flush operations",
 		}, []string{"operation"}).WithLabelValues("flush"),
-		
+
 		BufferEvictions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "buffer_evictions_total",
 			Help:      "Total number of buffer eviction operations",
 		}, []string{"operation"}).WithLabelValues("evict"),
-		
+
 		BufferHits: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "buffer_hits_total",
 			Help:      "Total number of buffer hits",
 		}, []string{"operation"}).WithLabelValues("hit"),
-		
+
 		BufferMisses: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "buffer_misses_total",
 			Help:      "Total number of buffer misses",
 		}, []string{"operation"}).WithLabelValues("miss"),
-		
+
 		BufferOperations: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "buffer_operations_total",
 			Help:      "Total number of buffer operations",
 		}, []string{"operation", "type"}),
-		
+
 		// Search operations
 		SearchOperations: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -572,21 +572,21 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Name:      "search_operations_total",
 			Help:      "Total number of search operations",
 		}, []string{"type"}).WithLabelValues("search"),
-		
+
 		SearchErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "search_errors_total",
 			Help:      "Total number of search errors",
 		}, []string{"type"}),
-		
+
 		ParallelSearchOperations: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "parallel_search_operations_total",
 			Help:      "Total number of parallel search operations",
 		}, []string{"type"}).WithLabelValues("parallel_search"),
-		
+
 		// Storage size
 		StorageSize: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
@@ -594,28 +594,28 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Name:      "storage_size_bytes",
 			Help:      "Current storage size in bytes",
 		}),
-		
+
 		VectorCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "vector_count",
 			Help:      "Current number of vectors",
 		}),
-		
+
 		SegmentCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "segment_count",
 			Help:      "Current number of segments",
 		}),
-		
+
 		BufferSize: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "buffer_size_bytes",
 			Help:      "Current buffer size in bytes",
 		}),
-		
+
 		// Errors
 		Errors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -624,7 +624,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Total number of errors",
 		}, []string{"component", "type"}),
 	}
-	
+
 	// Initialize histograms if enabled
 	if m.config.EnableHistograms {
 		metrics.SearchLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -634,7 +634,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Search operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"type"}).WithLabelValues("search")
-		
+
 		metrics.ParallelSearchLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -642,7 +642,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Parallel search operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"type"}).WithLabelValues("parallel_search")
-		
+
 		metrics.CompressionRatio = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -650,7 +650,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Compression ratio (compressed_size / original_size)",
 			Buckets:   []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
 		}, []string{"algorithm"}).WithLabelValues("lz4")
-		
+
 		metrics.InsertLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -658,7 +658,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Insert operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"operation"}).WithLabelValues("insert")
-		
+
 		metrics.ReadLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -666,7 +666,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Read operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"operation"}).WithLabelValues("read")
-		
+
 		metrics.DeleteLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -674,7 +674,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Delete operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"operation"}).WithLabelValues("delete")
-		
+
 		metrics.FlushLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -682,7 +682,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Flush operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"operation"}).WithLabelValues("flush")
-		
+
 		metrics.CompactionLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -690,14 +690,14 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Compaction operation latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"operation"}).WithLabelValues("compact")
-		
+
 		metrics.CompressionOps = promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
 			Name:      "compression_operations_total",
 			Help:      "Total number of compression operations",
 		}, []string{"algorithm"}).WithLabelValues("lz4")
-		
+
 		metrics.CompressionErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: m.config.Subsystem,
@@ -705,7 +705,7 @@ func (m *MetricsCollector) NewStorageMetrics() (*StorageMetrics, error) {
 			Help:      "Total number of compression errors",
 		}, []string{"algorithm"}).WithLabelValues("lz4")
 	}
-	
+
 	return metrics, nil
 }
 
@@ -714,7 +714,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 	if !m.config.Enabled {
 		return nil, ErrMetricsNotEnabled
 	}
-	
+
 	metrics := &ServiceMetrics{
 		// gRPC metrics
 		GRPCRequests: promauto.NewCounterVec(prometheus.CounterOpts{
@@ -723,21 +723,21 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Name:      "grpc_requests_total",
 			Help:      "Total number of gRPC requests",
 		}, []string{"service"}).WithLabelValues("grpc"),
-		
+
 		GRPCErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
 			Name:      "grpc_errors_total",
 			Help:      "Total number of gRPC errors",
 		}, []string{"service"}).WithLabelValues("grpc"),
-		
+
 		GRPCConnections: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
 			Name:      "grpc_connections",
 			Help:      "Current number of gRPC connections",
 		}),
-		
+
 		// HTTP metrics
 		HTTPRequests: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -745,21 +745,21 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Name:      "http_requests_total",
 			Help:      "Total number of HTTP requests",
 		}, []string{"method", "endpoint"}),
-		
+
 		HTTPErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
 			Name:      "http_errors_total",
 			Help:      "Total number of HTTP errors",
 		}, []string{"method", "endpoint", "status_code"}),
-		
+
 		HTTPConnections: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
 			Name:      "http_connections",
 			Help:      "Current number of HTTP connections",
 		}),
-		
+
 		// Health check metrics
 		HealthCheckErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
@@ -767,7 +767,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Name:      "health_check_errors_total",
 			Help:      "Total number of health check errors",
 		}, []string{"service"}).WithLabelValues("health"),
-		
+
 		// Service metrics
 		ServiceUptime: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
@@ -775,14 +775,14 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Name:      "uptime_seconds",
 			Help:      "Service uptime in seconds",
 		}),
-		
+
 		ServiceVersion: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
 			Name:      "version_info",
 			Help:      "Service version information",
 		}, []string{"version", "build"}),
-		
+
 		ServiceErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
@@ -790,7 +790,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Help:      "Total number of service errors",
 		}, []string{"component", "type"}),
 	}
-	
+
 	// Initialize histograms if enabled
 	if m.config.EnableHistograms {
 		metrics.GRPCLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -800,7 +800,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Help:      "gRPC request latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"method"}).WithLabelValues("grpc")
-		
+
 		metrics.HTTPLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
@@ -808,7 +808,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Help:      "HTTP request latency in seconds",
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"method", "endpoint"})
-		
+
 		metrics.HealthCheckLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.config.Namespace,
 			Subsystem: "service",
@@ -817,7 +817,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 			Buckets:   m.config.HistogramBuckets,
 		}, []string{"service"}).WithLabelValues("health")
 	}
-	
+
 	return metrics, nil
 }
 
@@ -825,7 +825,7 @@ func (m *MetricsCollector) NewServiceMetrics() (*ServiceMetrics, error) {
 func (m *MetricsCollector) collectMetrics() {
 	ticker := time.NewTicker(m.config.CollectInterval)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-ticker.C:
@@ -847,11 +847,11 @@ func (m *MetricsCollector) collectSystemMetrics() {
 func (m *MetricsCollector) Validate() error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	// Validate configuration
 	if err := validateMetricsConfig(m.config); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
-	
+
 	return nil
 }

--- a/internal/storage/buffer/manager.go
+++ b/internal/storage/buffer/manager.go
@@ -9,10 +9,10 @@ import (
 	"unsafe"
 
 	"go.uber.org/zap"
-	"vexdb/internal/config"
-	"vexdb/internal/logging"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/logging"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 var (

--- a/internal/storage/hashing/hasher_test.go
+++ b/internal/storage/hashing/hasher_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 )
 
 type mapConfig map[string]interface{}

--- a/internal/storage/search/dual.go
+++ b/internal/storage/search/dual.go
@@ -1,15 +1,15 @@
-// Package search provides dual search functionality for VexDB
+// Package search provides dual search functionality for VxDB
 package search
 
 import (
 	"context"
 	"sync"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage/buffer"
-	"vexdb/internal/storage/segment"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/buffer"
+	"vxdb/internal/storage/segment"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/filter.go
+++ b/internal/storage/search/filter.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/interface.go
+++ b/internal/storage/search/interface.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage/buffer"
-	"vexdb/internal/storage/segment"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/buffer"
+	"vxdb/internal/storage/segment"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/linear.go
+++ b/internal/storage/search/linear.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/merger.go
+++ b/internal/storage/search/merger.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/parallel.go
+++ b/internal/storage/search/parallel.go
@@ -1,14 +1,14 @@
-// Package search provides parallel search functionality for VexDB
+// Package search provides parallel search functionality for VxDB
 package search
 
 import (
 	"context"
 	"sync"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage/segment"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/segment"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/search/results.go
+++ b/internal/storage/search/results.go
@@ -1,5 +1,5 @@
 package search
 
-import "vexdb/internal/types"
+import "vxdb/internal/types"
 
 type SearchResult = types.SearchResult

--- a/internal/storage/search/topk.go
+++ b/internal/storage/search/topk.go
@@ -8,8 +8,8 @@ import (
 	"math"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
 
 	"go.uber.org/zap"
 )

--- a/internal/storage/segment/constants.go
+++ b/internal/storage/segment/constants.go
@@ -1,24 +1,24 @@
 package segment
 
 import (
-       "fmt"
-       "vexdb/internal/types"
+	"fmt"
+	"vxdb/internal/types"
 )
 
 // Segment magic number and version
 const (
-	SegmentMagic   = 0x56455844 // "VEXD" in hex
+	SegmentMagic   = 0x56455844 // "VXD" in hex
 	SegmentVersion = 1
 )
 
 // SegmentHeader represents the header of a segment file
 type SegmentHeader struct {
-	Magic      uint32    `json:"magic" yaml:"magic"`
-	Version    uint32    `json:"version" yaml:"version"`
-	ClusterID  uint32    `json:"cluster_id" yaml:"cluster_id"`
-	SegmentID  string    `json:"segment_id" yaml:"segment_id"`
-	Status     string    `json:"status" yaml:"status"`
-	VectorSize uint32    `json:"vector_size" yaml:"vector_size"`
+	Magic      uint32          `json:"magic" yaml:"magic"`
+	Version    uint32          `json:"version" yaml:"version"`
+	ClusterID  uint32          `json:"cluster_id" yaml:"cluster_id"`
+	SegmentID  string          `json:"segment_id" yaml:"segment_id"`
+	Status     string          `json:"status" yaml:"status"`
+	VectorSize uint32          `json:"vector_size" yaml:"vector_size"`
 	CreatedAt  types.Timestamp `json:"created_at" yaml:"created_at"`
 	UpdatedAt  types.Timestamp `json:"updated_at" yaml:"updated_at"`
 }
@@ -27,25 +27,25 @@ type SegmentHeader struct {
 type SegmentStatus string
 
 const (
-	SegmentStatusActive    SegmentStatus = "active"
-	SegmentStatusSealed    SegmentStatus = "sealed"
+	SegmentStatusActive     SegmentStatus = "active"
+	SegmentStatusSealed     SegmentStatus = "sealed"
 	SegmentStatusCompacting SegmentStatus = "compacting"
-	SegmentStatusDeleted   SegmentStatus = "deleted"
+	SegmentStatusDeleted    SegmentStatus = "deleted"
 )
 
 // SegmentInfo represents information about a segment
 type SegmentInfo struct {
-	ID          string        `json:"id" yaml:"id"`
-	ClusterID   uint32        `json:"cluster_id" yaml:"cluster_id"`
-	Status      SegmentStatus `json:"status" yaml:"status"`
-	VectorCount uint64        `json:"vector_count" yaml:"vector_count"`
+	ID          string          `json:"id" yaml:"id"`
+	ClusterID   uint32          `json:"cluster_id" yaml:"cluster_id"`
+	Status      SegmentStatus   `json:"status" yaml:"status"`
+	VectorCount uint64          `json:"vector_count" yaml:"vector_count"`
 	CreatedAt   types.Timestamp `json:"created_at" yaml:"created_at"`
 	UpdatedAt   types.Timestamp `json:"updated_at" yaml:"updated_at"`
 }
 
 // ClusterIDString returns a string representation of the cluster ID
 func (si *SegmentInfo) ClusterIDString() string {
-       return fmt.Sprintf("%d", si.ClusterID)
+	return fmt.Sprintf("%d", si.ClusterID)
 }
 
 // IsValid checks if the segment info is valid
@@ -92,12 +92,12 @@ func (si *SegmentInfo) IsDeleted() bool {
 func NewSegmentInfo(id string, clusterID uint32) *SegmentInfo {
 	now := types.NowTimestamp()
 	return &SegmentInfo{
-		ID:         id,
-		ClusterID:  clusterID,
-		Status:     SegmentStatusActive,
+		ID:          id,
+		ClusterID:   clusterID,
+		Status:      SegmentStatusActive,
 		VectorCount: 0,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 }
 

--- a/internal/storage/segment/format.go
+++ b/internal/storage/segment/format.go
@@ -1,70 +1,70 @@
 package segment
 
 import (
-    "encoding/binary"
-    "errors"
-    "fmt"
-    "hash/crc32"
-    "io"
-    "encoding/json"
-    "math"
-    "time"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"time"
 
-	"vexdb/internal/types"
+	"vxdb/internal/types"
 )
 
 const (
-    // FileSegmentMagic aliases the global segment magic to avoid redeclarations
-    FileSegmentMagic = SegmentMagic
-    // FileSegmentVersion aliases the global segment version
-    FileSegmentVersion = SegmentVersion
-    
-    // HeaderSize is the size of the segment header in bytes
-    HeaderSize = 64
-	
+	// FileSegmentMagic aliases the global segment magic to avoid redeclarations
+	FileSegmentMagic = SegmentMagic
+	// FileSegmentVersion aliases the global segment version
+	FileSegmentVersion = SegmentVersion
+
+	// HeaderSize is the size of the segment header in bytes
+	HeaderSize = 64
+
 	// FooterSize is the size of the segment footer in bytes
 	FooterSize = 32
-	
+
 	// IndexEntrySize is the size of each index entry in bytes
 	IndexEntrySize = 32
-	
+
 	// DefaultMaxVectorsPerSegment is the default maximum number of vectors per segment
 	DefaultMaxVectorsPerSegment = 10000
-	
+
 	// DefaultCompressionLevel is the default compression level
 	DefaultCompressionLevel = 1
 )
 
 var (
-    ErrInvalidMagic      = errors.New("invalid segment magic number")
-    ErrInvalidVersion    = errors.New("unsupported segment version")
-    ErrCorruptedData     = errors.New("segment data is corrupted")
-    ErrSegmentFull       = errors.New("segment is full")
-    FileErrVectorNotFound    = errors.New("vector not found")
-    FileErrInvalidOffset     = errors.New("invalid vector offset")
-    ErrChecksumMismatch  = errors.New("checksum mismatch")
+	ErrInvalidMagic       = errors.New("invalid segment magic number")
+	ErrInvalidVersion     = errors.New("unsupported segment version")
+	ErrCorruptedData      = errors.New("segment data is corrupted")
+	ErrSegmentFull        = errors.New("segment is full")
+	FileErrVectorNotFound = errors.New("vector not found")
+	FileErrInvalidOffset  = errors.New("invalid vector offset")
+	ErrChecksumMismatch   = errors.New("checksum mismatch")
 )
 
 // Header represents the segment file header
 type FileHeader struct {
-    Magic        uint32
-    Version      uint32
-    CreatedAt    int64
-	ModifiedAt   int64
-	VectorCount  uint32
-	VectorDim    uint32
-	ClusterID    uint32
-	MaxVectors   uint32
-	Flags        uint32
-	Reserved     [32]byte
-	Checksum     uint32
+	Magic       uint32
+	Version     uint32
+	CreatedAt   int64
+	ModifiedAt  int64
+	VectorCount uint32
+	VectorDim   uint32
+	ClusterID   uint32
+	MaxVectors  uint32
+	Flags       uint32
+	Reserved    [32]byte
+	Checksum    uint32
 }
 
 // Footer represents the segment file footer
 type FileFooter struct {
-    IndexOffset  uint64
-    IndexSize    uint64
-    DataOffset   uint64
+	IndexOffset  uint64
+	IndexSize    uint64
+	DataOffset   uint64
 	DataSize     uint64
 	MetadataSize uint32
 	Flags        uint32
@@ -73,19 +73,19 @@ type FileFooter struct {
 
 // IndexEntry represents an entry in the segment index
 type FileIndexEntry struct {
-    VectorID     uint64
-    Offset       uint64
-    Size         uint32
-	ClusterID    uint32
-	Checksum     uint32
-	Reserved     [12]byte
+	VectorID  uint64
+	Offset    uint64
+	Size      uint32
+	ClusterID uint32
+	Checksum  uint32
+	Reserved  [12]byte
 }
 
 // VectorHeader represents the header for each vector in the segment
 type FileVectorHeader struct {
-    VectorID     uint64
-    Timestamp    int64
-    MetadataSize uint32
+	VectorID     uint64
+	Timestamp    int64
+	MetadataSize uint32
 	VectorSize   uint32
 	Flags        uint32
 	Checksum     uint32
@@ -93,36 +93,36 @@ type FileVectorHeader struct {
 
 // Segment represents a segment file
 type FileSegment struct {
-    header       *FileHeader
-    footer       *FileFooter
-    index        []*FileIndexEntry
-    vectors      map[uint64]*types.Vector
-    metadata     map[uint64][]byte
-    path         string
-	maxVectors   int
-	compression  int
-	isReadOnly   bool
-	dirty        bool
+	header      *FileHeader
+	footer      *FileFooter
+	index       []*FileIndexEntry
+	vectors     map[uint64]*types.Vector
+	metadata    map[uint64][]byte
+	path        string
+	maxVectors  int
+	compression int
+	isReadOnly  bool
+	dirty       bool
 }
 
 // NewSegment creates a new segment
 func NewFileSegment(path string, vectorDim uint32, clusterID uint32, maxVectors int) *FileSegment {
 	now := time.Now().Unix()
-	
-    return &FileSegment{
-        header: &FileHeader{
-            Magic:       FileSegmentMagic,
-            Version:     FileSegmentVersion,
-			CreatedAt:   now,
-			ModifiedAt:  now,
-			VectorDim:   vectorDim,
-			ClusterID:   clusterID,
-			MaxVectors:  uint32(maxVectors),
+
+	return &FileSegment{
+		header: &FileHeader{
+			Magic:      FileSegmentMagic,
+			Version:    FileSegmentVersion,
+			CreatedAt:  now,
+			ModifiedAt: now,
+			VectorDim:  vectorDim,
+			ClusterID:  clusterID,
+			MaxVectors: uint32(maxVectors),
 		},
-        footer:      &FileFooter{},
-        index:       make([]*FileIndexEntry, 0, maxVectors),
-        vectors:     make(map[uint64]*types.Vector),
-        metadata:    make(map[uint64][]byte),
+		footer:      &FileFooter{},
+		index:       make([]*FileIndexEntry, 0, maxVectors),
+		vectors:     make(map[uint64]*types.Vector),
+		metadata:    make(map[uint64][]byte),
 		path:        path,
 		maxVectors:  maxVectors,
 		compression: DefaultCompressionLevel,
@@ -135,43 +135,43 @@ func NewFileSegment(path string, vectorDim uint32, clusterID uint32, maxVectors 
 func LoadFileSegment(path string) (*FileSegment, error) {
 	// This would be implemented to read from disk
 	// For now, return a new segment
-    return NewFileSegment(path, 128, 0, DefaultMaxVectorsPerSegment), nil
+	return NewFileSegment(path, 128, 0, DefaultMaxVectorsPerSegment), nil
 }
 
 // AddVector adds a vector to the segment
 func (s *FileSegment) AddVector(vector *types.Vector) error {
-    if s.isReadOnly {
-        return ErrSegmentFull
-    }
-	
+	if s.isReadOnly {
+		return ErrSegmentFull
+	}
+
 	if len(s.vectors) >= s.maxVectors {
 		return ErrSegmentFull
 	}
-	
-    key := idToU64(vector.ID)
-    if _, exists := s.vectors[key]; exists {
-        return fmt.Errorf("vector with ID '%s' already exists", vector.ID)
-    }
-	
-    s.vectors[key] = vector
-    if vector.Metadata != nil {
-        s.metadata[key] = encodeMetadata(vector.Metadata)
-    }
-	
+
+	key := idToU64(vector.ID)
+	if _, exists := s.vectors[key]; exists {
+		return fmt.Errorf("vector with ID '%s' already exists", vector.ID)
+	}
+
+	s.vectors[key] = vector
+	if vector.Metadata != nil {
+		s.metadata[key] = encodeMetadata(vector.Metadata)
+	}
+
 	s.header.VectorCount++
 	s.header.ModifiedAt = time.Now().Unix()
 	s.dirty = true
-	
+
 	return nil
 }
 
 // GetVector retrieves a vector from the segment
 func (s *FileSegment) GetVectorByKey(key uint64) (*types.Vector, error) {
-    vector, exists := s.vectors[key]
-    if !exists {
-        return nil, FileErrVectorNotFound
-    }
-    return vector, nil
+	vector, exists := s.vectors[key]
+	if !exists {
+		return nil, FileErrVectorNotFound
+	}
+	return vector, nil
 }
 
 // RemoveVector removes a vector from the segment
@@ -179,14 +179,14 @@ func (s *FileSegment) RemoveVector(vectorID uint64) error {
 	if s.isReadOnly {
 		return ErrSegmentFull
 	}
-	
-    if _, exists := s.vectors[vectorID]; !exists {
-        return ErrVectorNotFound
-    }
-	
+
+	if _, exists := s.vectors[vectorID]; !exists {
+		return ErrVectorNotFound
+	}
+
 	delete(s.vectors, vectorID)
 	delete(s.metadata, vectorID)
-	
+
 	// Remove from index
 	for i, entry := range s.index {
 		if entry.VectorID == vectorID {
@@ -194,11 +194,11 @@ func (s *FileSegment) RemoveVector(vectorID uint64) error {
 			break
 		}
 	}
-	
+
 	s.header.VectorCount--
 	s.header.ModifiedAt = time.Now().Unix()
 	s.dirty = true
-	
+
 	return nil
 }
 
@@ -240,35 +240,35 @@ func (s *FileSegment) IsDirty() bool {
 func (s *FileSegment) Serialize() ([]byte, error) {
 	// Create buffer
 	buf := make([]byte, 0)
-	
+
 	// Serialize header
 	headerBytes, err := s.serializeHeader()
 	if err != nil {
 		return nil, err
 	}
 	buf = append(buf, headerBytes...)
-	
+
 	// Serialize data
 	dataBytes, err := s.serializeData()
 	if err != nil {
 		return nil, err
 	}
 	buf = append(buf, dataBytes...)
-	
+
 	// Serialize index
 	indexBytes, err := s.serializeIndex()
 	if err != nil {
 		return nil, err
 	}
 	buf = append(buf, indexBytes...)
-	
+
 	// Serialize footer
 	footerBytes, err := s.serializeFooter()
 	if err != nil {
 		return nil, err
 	}
 	buf = append(buf, footerBytes...)
-	
+
 	return buf, nil
 }
 
@@ -277,18 +277,18 @@ func (s *FileSegment) Deserialize(data []byte) error {
 	if len(data) < HeaderSize+FooterSize {
 		return ErrCorruptedData
 	}
-	
+
 	// Deserialize header
 	if err := s.deserializeHeader(data[:HeaderSize]); err != nil {
 		return err
 	}
-	
+
 	// Deserialize footer
 	footerStart := len(data) - FooterSize
 	if err := s.deserializeFooter(data[footerStart:]); err != nil {
 		return err
 	}
-	
+
 	// Deserialize data
 	dataStart := HeaderSize
 	dataEnd := int(s.footer.DataOffset + s.footer.DataSize)
@@ -298,7 +298,7 @@ func (s *FileSegment) Deserialize(data []byte) error {
 	if err := s.deserializeData(data[dataStart:dataEnd]); err != nil {
 		return err
 	}
-	
+
 	// Deserialize index
 	indexStart := int(s.footer.IndexOffset)
 	indexEnd := indexStart + int(s.footer.IndexSize)
@@ -308,7 +308,7 @@ func (s *FileSegment) Deserialize(data []byte) error {
 	if err := s.deserializeIndex(data[indexStart:indexEnd]); err != nil {
 		return err
 	}
-	
+
 	s.dirty = false
 	return nil
 }
@@ -316,7 +316,7 @@ func (s *FileSegment) Deserialize(data []byte) error {
 // serializeHeader serializes the segment header
 func (s *FileSegment) serializeHeader() ([]byte, error) {
 	buf := make([]byte, HeaderSize)
-	
+
 	binary.LittleEndian.PutUint32(buf[0:4], s.header.Magic)
 	binary.LittleEndian.PutUint32(buf[4:8], s.header.Version)
 	binary.LittleEndian.PutUint64(buf[8:16], uint64(s.header.CreatedAt))
@@ -326,11 +326,11 @@ func (s *FileSegment) serializeHeader() ([]byte, error) {
 	binary.LittleEndian.PutUint32(buf[32:36], s.header.ClusterID)
 	binary.LittleEndian.PutUint32(buf[36:40], s.header.MaxVectors)
 	binary.LittleEndian.PutUint32(buf[40:44], s.header.Flags)
-	
+
 	// Calculate checksum
 	checksum := crc32.ChecksumIEEE(buf[:44])
 	binary.LittleEndian.PutUint32(buf[60:64], checksum)
-	
+
 	return buf, nil
 }
 
@@ -339,7 +339,7 @@ func (s *FileSegment) deserializeHeader(data []byte) error {
 	if len(data) != HeaderSize {
 		return ErrCorruptedData
 	}
-	
+
 	s.header.Magic = binary.LittleEndian.Uint32(data[0:4])
 	s.header.Version = binary.LittleEndian.Uint32(data[4:8])
 	s.header.CreatedAt = int64(binary.LittleEndian.Uint64(data[8:16]))
@@ -349,13 +349,13 @@ func (s *FileSegment) deserializeHeader(data []byte) error {
 	s.header.ClusterID = binary.LittleEndian.Uint32(data[32:36])
 	s.header.MaxVectors = binary.LittleEndian.Uint32(data[36:40])
 	s.header.Flags = binary.LittleEndian.Uint32(data[40:44])
-	
+
 	// Verify checksum
 	checksum := crc32.ChecksumIEEE(data[:44])
 	if checksum != binary.LittleEndian.Uint32(data[60:64]) {
 		return ErrChecksumMismatch
 	}
-	
+
 	// Verify magic and version
 	if s.header.Magic != SegmentMagic {
 		return ErrInvalidMagic
@@ -363,45 +363,45 @@ func (s *FileSegment) deserializeHeader(data []byte) error {
 	if s.header.Version != SegmentVersion {
 		return ErrInvalidVersion
 	}
-	
+
 	return nil
 }
 
 // serializeData serializes the segment data
 func (s *FileSegment) serializeData() ([]byte, error) {
 	buf := make([]byte, 0)
-	
+
 	for _, vector := range s.vectors {
 		// Serialize vector header
-            vectorHeader := &FileVectorHeader{
-                VectorID:     idToU64(vector.ID),
-                Timestamp:    vector.Timestamp,
-                VectorSize:   uint32(len(vector.Data) * 4), // float32 = 4 bytes
-                Flags:        0,
-            }
-		
-            key := idToU64(vector.ID)
-            if metadata, exists := s.metadata[key]; exists {
-                vectorHeader.MetadataSize = uint32(len(metadata))
-            }
-		
+		vectorHeader := &FileVectorHeader{
+			VectorID:   idToU64(vector.ID),
+			Timestamp:  vector.Timestamp,
+			VectorSize: uint32(len(vector.Data) * 4), // float32 = 4 bytes
+			Flags:      0,
+		}
+
+		key := idToU64(vector.ID)
+		if metadata, exists := s.metadata[key]; exists {
+			vectorHeader.MetadataSize = uint32(len(metadata))
+		}
+
 		headerBytes := make([]byte, 24)
 		binary.LittleEndian.PutUint64(headerBytes[0:8], vectorHeader.VectorID)
 		binary.LittleEndian.PutUint64(headerBytes[8:16], uint64(vectorHeader.Timestamp))
 		binary.LittleEndian.PutUint32(headerBytes[16:20], vectorHeader.MetadataSize)
 		binary.LittleEndian.PutUint32(headerBytes[20:24], vectorHeader.VectorSize)
-		
+
 		// Calculate checksum
 		checksum := crc32.ChecksumIEEE(headerBytes[:20])
 		binary.LittleEndian.PutUint32(headerBytes[20:24], checksum)
-		
+
 		buf = append(buf, headerBytes...)
-		
+
 		// Serialize metadata
-            if vectorHeader.MetadataSize > 0 {
-                buf = append(buf, s.metadata[key]...)
-            }
-		
+		if vectorHeader.MetadataSize > 0 {
+			buf = append(buf, s.metadata[key]...)
+		}
+
 		// Serialize vector data
 		vectorBytes := make([]byte, len(vector.Data)*4)
 		for i, val := range vector.Data {
@@ -409,34 +409,34 @@ func (s *FileSegment) serializeData() ([]byte, error) {
 		}
 		buf = append(buf, vectorBytes...)
 	}
-	
+
 	return buf, nil
 }
 
 // deserializeData deserializes the segment data
 func (s *FileSegment) deserializeData(data []byte) error {
 	offset := 0
-	
+
 	for offset < len(data) {
 		if offset+24 > len(data) {
 			return ErrCorruptedData
 		}
-		
+
 		// Read vector header
-        vectorHeader := &FileVectorHeader{}
-		vectorHeader.VectorID = binary.LittleEndian.Uint64(data[offset:offset+8])
-		vectorHeader.Timestamp = int64(binary.LittleEndian.Uint64(data[offset+8:offset+16]))
-		vectorHeader.MetadataSize = binary.LittleEndian.Uint32(data[offset+16:offset+20])
-		vectorHeader.VectorSize = binary.LittleEndian.Uint32(data[offset+20:offset+24])
-		
+		vectorHeader := &FileVectorHeader{}
+		vectorHeader.VectorID = binary.LittleEndian.Uint64(data[offset : offset+8])
+		vectorHeader.Timestamp = int64(binary.LittleEndian.Uint64(data[offset+8 : offset+16]))
+		vectorHeader.MetadataSize = binary.LittleEndian.Uint32(data[offset+16 : offset+20])
+		vectorHeader.VectorSize = binary.LittleEndian.Uint32(data[offset+20 : offset+24])
+
 		// Verify checksum
-		checksum := crc32.ChecksumIEEE(data[offset:offset+20])
+		checksum := crc32.ChecksumIEEE(data[offset : offset+20])
 		if checksum != binary.LittleEndian.Uint32(data[offset+20:offset+24]) {
 			return ErrChecksumMismatch
 		}
-		
+
 		offset += 24
-		
+
 		// Read metadata
 		var metadata []byte
 		if vectorHeader.MetadataSize > 0 {
@@ -446,7 +446,7 @@ func (s *FileSegment) deserializeData(data []byte) error {
 			metadata = data[offset : offset+int(vectorHeader.MetadataSize)]
 			offset += int(vectorHeader.MetadataSize)
 		}
-		
+
 		// Read vector data
 		if offset+int(vectorHeader.VectorSize) > len(data) {
 			return ErrCorruptedData
@@ -456,36 +456,36 @@ func (s *FileSegment) deserializeData(data []byte) error {
 			vectorData[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[offset+i*4 : offset+(i+1)*4]))
 		}
 		offset += int(vectorHeader.VectorSize)
-		
+
 		// Create vector
-        vector := &types.Vector{
-            ID:        fmt.Sprintf("%d", vectorHeader.VectorID),
-            Data:      vectorData,
-            Timestamp: vectorHeader.Timestamp,
-        }
-		
-            if len(metadata) > 0 {
-                var md map[string]interface{}
-                if err := json.Unmarshal(metadata, &md); err == nil {
-                    vector.Metadata = md
-                }
-            }
-		
-        key := vectorHeader.VectorID
-        s.vectors[key] = vector
-        if len(metadata) > 0 {
-            s.metadata[key] = metadata
-        }
+		vector := &types.Vector{
+			ID:        fmt.Sprintf("%d", vectorHeader.VectorID),
+			Data:      vectorData,
+			Timestamp: vectorHeader.Timestamp,
+		}
+
+		if len(metadata) > 0 {
+			var md map[string]interface{}
+			if err := json.Unmarshal(metadata, &md); err == nil {
+				vector.Metadata = md
+			}
+		}
+
+		key := vectorHeader.VectorID
+		s.vectors[key] = vector
+		if len(metadata) > 0 {
+			s.metadata[key] = metadata
+		}
 	}
-	
+
 	return nil
 }
 
 // serializeIndex serializes the segment index
 func (s *FileSegment) serializeIndex() ([]byte, error) {
 	buf := make([]byte, len(s.index)*IndexEntrySize)
-	
-    for i, entry := range s.index {
+
+	for i, entry := range s.index {
 		offset := i * IndexEntrySize
 		binary.LittleEndian.PutUint64(buf[offset:offset+8], entry.VectorID)
 		binary.LittleEndian.PutUint64(buf[offset+8:offset+16], entry.Offset)
@@ -493,7 +493,7 @@ func (s *FileSegment) serializeIndex() ([]byte, error) {
 		binary.LittleEndian.PutUint32(buf[offset+20:offset+24], entry.ClusterID)
 		binary.LittleEndian.PutUint32(buf[offset+24:offset+28], entry.Checksum)
 	}
-	
+
 	return buf, nil
 }
 
@@ -502,38 +502,38 @@ func (s *FileSegment) deserializeIndex(data []byte) error {
 	if len(data)%IndexEntrySize != 0 {
 		return ErrCorruptedData
 	}
-	
-    s.index = make([]*FileIndexEntry, 0, len(data)/IndexEntrySize)
-	
+
+	s.index = make([]*FileIndexEntry, 0, len(data)/IndexEntrySize)
+
 	for i := 0; i < len(data); i += IndexEntrySize {
-        entry := &FileIndexEntry{}
-		entry.VectorID = binary.LittleEndian.Uint64(data[i:i+8])
-		entry.Offset = binary.LittleEndian.Uint64(data[i+8:i+16])
-		entry.Size = binary.LittleEndian.Uint32(data[i+16:i+20])
-		entry.ClusterID = binary.LittleEndian.Uint32(data[i+20:i+24])
-		entry.Checksum = binary.LittleEndian.Uint32(data[i+24:i+28])
-		
-        s.index = append(s.index, entry)
+		entry := &FileIndexEntry{}
+		entry.VectorID = binary.LittleEndian.Uint64(data[i : i+8])
+		entry.Offset = binary.LittleEndian.Uint64(data[i+8 : i+16])
+		entry.Size = binary.LittleEndian.Uint32(data[i+16 : i+20])
+		entry.ClusterID = binary.LittleEndian.Uint32(data[i+20 : i+24])
+		entry.Checksum = binary.LittleEndian.Uint32(data[i+24 : i+28])
+
+		s.index = append(s.index, entry)
 	}
-	
+
 	return nil
 }
 
 // serializeFooter serializes the segment footer
 func (s *FileSegment) serializeFooter() ([]byte, error) {
 	buf := make([]byte, FooterSize)
-	
+
 	binary.LittleEndian.PutUint64(buf[0:8], s.footer.IndexOffset)
 	binary.LittleEndian.PutUint64(buf[8:16], s.footer.IndexSize)
 	binary.LittleEndian.PutUint64(buf[16:24], s.footer.DataOffset)
 	binary.LittleEndian.PutUint64(buf[24:32], s.footer.DataSize)
 	binary.LittleEndian.PutUint32(buf[32:36], s.footer.MetadataSize)
 	binary.LittleEndian.PutUint32(buf[36:40], s.footer.Flags)
-	
+
 	// Calculate checksum
 	checksum := crc32.ChecksumIEEE(buf[:36])
 	binary.LittleEndian.PutUint32(buf[28:32], checksum)
-	
+
 	return buf, nil
 }
 
@@ -542,20 +542,20 @@ func (s *FileSegment) deserializeFooter(data []byte) error {
 	if len(data) != FooterSize {
 		return ErrCorruptedData
 	}
-	
+
 	s.footer.IndexOffset = binary.LittleEndian.Uint64(data[0:8])
 	s.footer.IndexSize = binary.LittleEndian.Uint64(data[8:16])
 	s.footer.DataOffset = binary.LittleEndian.Uint64(data[16:24])
 	s.footer.DataSize = binary.LittleEndian.Uint64(data[24:32])
 	s.footer.MetadataSize = binary.LittleEndian.Uint32(data[32:36])
 	s.footer.Flags = binary.LittleEndian.Uint32(data[36:40])
-	
+
 	// Verify checksum
 	checksum := crc32.ChecksumIEEE(data[:36])
 	if checksum != binary.LittleEndian.Uint32(data[28:32]) {
 		return ErrChecksumMismatch
 	}
-	
+
 	return nil
 }
 
@@ -565,12 +565,12 @@ func (s *FileSegment) WriteTo(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	
+
 	_, err = w.Write(data)
 	if err != nil {
 		return err
 	}
-	
+
 	s.dirty = false
 	return nil
 }
@@ -582,26 +582,26 @@ func (s *FileSegment) ReadFrom(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	
+
 	return s.Deserialize(data)
 }
 
 // GetSize returns the size of the segment in bytes
 func (s *FileSegment) GetSize() int {
 	size := HeaderSize + FooterSize
-	
+
 	// Calculate data size
-    for id, vector := range s.vectors {
-        size += 24 // Vector header size
-        if metadata, exists := s.metadata[id]; exists {
-            size += len(metadata)
-        }
-        size += len(vector.Data) * 4 // float32 = 4 bytes
-    }
-	
+	for id, vector := range s.vectors {
+		size += 24 // Vector header size
+		if metadata, exists := s.metadata[id]; exists {
+			size += len(metadata)
+		}
+		size += len(vector.Data) * 4 // float32 = 4 bytes
+	}
+
 	// Calculate index size
 	size += len(s.index) * IndexEntrySize
-	
+
 	return size
 }
 
@@ -630,11 +630,11 @@ func (s *FileSegment) Compact() error {
 	if s.isReadOnly {
 		return ErrSegmentFull
 	}
-	
+
 	// Create new vectors and metadata maps
 	newVectors := make(map[uint64]*types.Vector)
 	newMetadata := make(map[uint64][]byte)
-	
+
 	// Copy existing vectors
 	for id, vector := range s.vectors {
 		newVectors[id] = vector
@@ -642,13 +642,13 @@ func (s *FileSegment) Compact() error {
 			newMetadata[id] = metadata
 		}
 	}
-	
+
 	s.vectors = newVectors
 	s.metadata = newMetadata
 	s.header.VectorCount = uint32(len(s.vectors))
 	s.header.ModifiedAt = time.Now().Unix()
 	s.dirty = true
-	
+
 	return nil
 }
 
@@ -661,18 +661,18 @@ func (s *FileSegment) Validate() error {
 	if s.header.Version != SegmentVersion {
 		return ErrInvalidVersion
 	}
-	
+
 	// Validate vector count
 	if uint32(len(s.vectors)) != s.header.VectorCount {
 		return ErrCorruptedData
 	}
-	
-    // Validate vectors
-    for _, vector := range s.vectors {
-        if len(vector.Data) != int(s.header.VectorDim) {
-            return ErrCorruptedData
-        }
-    }
-	
+
+	// Validate vectors
+	for _, vector := range s.vectors {
+		if len(vector.Data) != int(s.header.VectorDim) {
+			return ErrCorruptedData
+		}
+	}
+
 	return nil
 }

--- a/internal/storage/segment/helpers.go
+++ b/internal/storage/segment/helpers.go
@@ -1,22 +1,25 @@
 package segment
 
 import (
-    "encoding/json"
-    "hash/fnv"
+	"encoding/json"
+	"hash/fnv"
 )
 
 // idToU64 provides a stable uint64 key for a string ID
 func idToU64(id string) uint64 {
-    h := fnv.New64a()
-    _, _ = h.Write([]byte(id))
-    return h.Sum64()
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(id))
+	return h.Sum64()
 }
 
 // encodeMetadata serializes metadata map to JSON bytes (best-effort)
 func encodeMetadata(m map[string]interface{}) []byte {
-    if m == nil { return nil }
-    b, err := json.Marshal(m)
-    if err != nil { return nil }
-    return b
+	if m == nil {
+		return nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return b
 }
-

--- a/internal/storage/segment/manager.go
+++ b/internal/storage/segment/manager.go
@@ -1,30 +1,30 @@
-// Package segment provides segment management functionality for VexDB
+// Package segment provides segment management functionality for VxDB
 package segment
 
 import (
-    "context"
-    "sync"
+	"context"
+	"sync"
 
-    "vexdb/internal/config"
-    "vexdb/internal/metrics"
-    "vexdb/internal/storage/compression"
-    "vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/compression"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )
 
 // Manager manages all segments in the storage system
 type Manager struct {
-    config      *config.Config
-	logger      *zap.Logger
-	metrics     *metrics.Collector
-	compressor  *compression.Compressor
-	
-	segments    map[string]*Segment
-	manifest    *Manifest
-	
-	mu          sync.RWMutex
-	started     bool
+	config     *config.Config
+	logger     *zap.Logger
+	metrics    *metrics.Collector
+	compressor *compression.Compressor
+
+	segments map[string]*Segment
+	manifest *Manifest
+
+	mu      sync.RWMutex
+	started bool
 }
 
 // NewManager creates a new segment manager
@@ -47,13 +47,15 @@ func NewManager(cfg *config.Config, logger *zap.Logger, metrics *metrics.Collect
 
 // initializeManifest initializes the segment manifest
 func (m *Manager) initializeManifest() error {
-    // Initialize manifest (using default path and types)
-    m.manifest = NewManifest("./data/manifest.vex", 0, 0, *m.logger, nil)
-    // Load or create
-    if err := m.manifest.Load(); err != nil {
-        m.logger.Warn("Failed to load manifest, creating new one", zap.Error(err))
-        if err := m.manifest.Create(); err != nil { return err }
-    }
+	// Initialize manifest (using default path and types)
+	m.manifest = NewManifest("./data/manifest.vx", 0, 0, *m.logger, nil)
+	// Load or create
+	if err := m.manifest.Load(); err != nil {
+		m.logger.Warn("Failed to load manifest, creating new one", zap.Error(err))
+		if err := m.manifest.Create(); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -77,7 +79,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			m.logger.Error("Failed to create segment", zap.String("segment_id", info.ID), zap.Error(err))
 			continue
 		}
-		
+
 		m.segments[info.ID] = segment
 	}
 
@@ -126,7 +128,7 @@ func (m *Manager) CreateSegment(clusterID uint32) (*Segment, error) {
 
 	// Generate segment ID
 	segmentID := generateSegmentID(clusterID)
-	
+
 	// Create segment info
 	info := &SegmentInfo{
 		ID:        segmentID,

--- a/internal/storage/segment/reader.go
+++ b/internal/storage/segment/reader.go
@@ -1,46 +1,46 @@
 package segment
 
 import (
-    "encoding/binary"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "io"
-    "hash/crc32"
-    "math"
-    "os"
-    "sync"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"os"
+	"sync"
 
-    "vexdb/internal/config"
-    "vexdb/internal/metrics"
-    "vexdb/internal/storage/compression"
-    "vexdb/internal/types"
-    "go.uber.org/zap"
+	"go.uber.org/zap"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/compression"
+	"vxdb/internal/types"
 )
 
 var (
-    ErrSegmentNotOpen    = errors.New("segment not open")
-    ErrReaderClosed      = errors.New("reader is closed")
-    ErrInvalidOffset     = errors.New("invalid offset")
-    ErrReadFailed        = errors.New("read failed")
-    ErrSeekFailed        = errors.New("seek failed")
-    ErrVectorNotFound    = errors.New("vector not found")
+	ErrSegmentNotOpen    = errors.New("segment not open")
+	ErrReaderClosed      = errors.New("reader is closed")
+	ErrInvalidOffset     = errors.New("invalid offset")
+	ErrReadFailed        = errors.New("read failed")
+	ErrSeekFailed        = errors.New("seek failed")
+	ErrVectorNotFound    = errors.New("vector not found")
 	ErrCorruptedIndex    = errors.New("corrupted index")
 	ErrInvalidVectorSize = errors.New("invalid vector size")
 )
 
 // ReaderConfig represents the configuration for the segment reader
 type ReaderConfig struct {
-	MaxOpenFiles       int           `yaml:"max_open_files" json:"max_open_files"`
-	ReadBufferSize     int           `yaml:"read_buffer_size" json:"read_buffer_size"`
-	EnableMMap         bool          `yaml:"enable_mmap" json:"enable_mmap"`
-	EnablePrefetch     bool          `yaml:"enable_prefetch" json:"enable_prefetch"`
-	PrefetchDistance   int           `yaml:"prefetch_distance" json:"prefetch_distance"`
-	CacheSize          int           `yaml:"cache_size" json:"cache_size"`
-	EnableReadAhead    bool          `yaml:"enable_read_ahead" json:"enable_read_ahead"`
-	ReadAheadSize      int           `yaml:"read_ahead_size" json:"read_ahead_size"`
-	DataDir            string        `yaml:"data_dir" json:"data_dir"`
-	EnableChecksum     bool          `yaml:"enable_checksum" json:"enable_checksum"`
+	MaxOpenFiles     int    `yaml:"max_open_files" json:"max_open_files"`
+	ReadBufferSize   int    `yaml:"read_buffer_size" json:"read_buffer_size"`
+	EnableMMap       bool   `yaml:"enable_mmap" json:"enable_mmap"`
+	EnablePrefetch   bool   `yaml:"enable_prefetch" json:"enable_prefetch"`
+	PrefetchDistance int    `yaml:"prefetch_distance" json:"prefetch_distance"`
+	CacheSize        int    `yaml:"cache_size" json:"cache_size"`
+	EnableReadAhead  bool   `yaml:"enable_read_ahead" json:"enable_read_ahead"`
+	ReadAheadSize    int    `yaml:"read_ahead_size" json:"read_ahead_size"`
+	DataDir          string `yaml:"data_dir" json:"data_dir"`
+	EnableChecksum   bool   `yaml:"enable_checksum" json:"enable_checksum"`
 }
 
 // DefaultReaderConfig returns the default reader configuration
@@ -61,27 +61,27 @@ func DefaultReaderConfig() *ReaderConfig {
 
 // Reader represents a segment reader
 type Reader struct {
-    config      *ReaderConfig
-    segment     *FileSegment
-	file        *os.File
-	path        string
-	mmapData    []byte
-    index       map[uint64]*FileIndexEntry
-	cache       map[uint64]*types.Vector
-	mu          sync.RWMutex
-	closed      bool
-    logger      *zap.Logger
-    metrics     *metrics.Collector
-	readBuffer  []byte
-	openFiles   map[string]*os.File
-	fileCount   int
+	config     *ReaderConfig
+	segment    *FileSegment
+	file       *os.File
+	path       string
+	mmapData   []byte
+	index      map[uint64]*FileIndexEntry
+	cache      map[uint64]*types.Vector
+	mu         sync.RWMutex
+	closed     bool
+	logger     *zap.Logger
+	metrics    *metrics.Collector
+	readBuffer []byte
+	openFiles  map[string]*os.File
+	fileCount  int
 }
 
 // NewReader creates a new segment reader
 func NewReader(cfg *config.Config, logger *zap.Logger, metrics *metrics.Collector, _ *compression.Compressor, _ *os.File) (*Reader, error) {
-    readerConfig := DefaultReaderConfig()
-    // ignore cfg overrides for now
-	
+	readerConfig := DefaultReaderConfig()
+	// ignore cfg overrides for now
+
 	return &Reader{
 		config:     readerConfig,
 		logger:     logger,
@@ -96,70 +96,70 @@ func NewReader(cfg *config.Config, logger *zap.Logger, metrics *metrics.Collecto
 func (r *Reader) Open(path string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	
+
 	if r.closed {
 		return ErrReaderClosed
 	}
-	
+
 	if r.segment != nil {
 		return ErrSegmentExists
 	}
-	
+
 	// Check if file exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return fmt.Errorf("segment file not found: %s", path)
 	}
-	
+
 	// Load segment
-    segment, err := LoadFileSegment(path)
+	segment, err := LoadFileSegment(path)
 	if err != nil {
 		return fmt.Errorf("failed to load segment: %w", err)
 	}
-	
+
 	// Open file
 	file, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to open segment file: %w", err)
 	}
-	
+
 	// Read segment data
-    data, err := io.ReadAll(file)
-    if err != nil {
-        _ = file.Close()
-        return fmt.Errorf("failed to read segment data: %w", err)
-    }
-	
+	data, err := io.ReadAll(file)
+	if err != nil {
+		_ = file.Close()
+		return fmt.Errorf("failed to read segment data: %w", err)
+	}
+
 	// Deserialize segment
-    if err := segment.Deserialize(data); err != nil {
-        _ = file.Close()
-        return fmt.Errorf("failed to deserialize segment: %w", err)
-    }
-	
+	if err := segment.Deserialize(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("failed to deserialize segment: %w", err)
+	}
+
 	// Build index
-    index := make(map[uint64]*FileIndexEntry)
+	index := make(map[uint64]*FileIndexEntry)
 	for _, entry := range segment.index {
 		index[entry.VectorID] = entry
 	}
-	
+
 	r.segment = segment
 	r.path = path
 	r.file = file
 	r.index = index
-	
+
 	// Enable memory mapping if configured
 	if r.config.EnableMMap {
-            if err := r.enableMMap(); err != nil {
-                r.logger.Warn("Failed to enable memory mapping", zap.Error(err))
-            }
+		if err := r.enableMMap(); err != nil {
+			r.logger.Warn("Failed to enable memory mapping", zap.Error(err))
+		}
 	}
-	
-    r.logger.Info("Opened segment for reading",
-        zap.String("path", path),
-        zap.Uint32("cluster_id", segment.GetClusterID()),
-        zap.Uint32("vector_dim", segment.GetVectorDim()),
-        zap.Int("vector_count", segment.GetVectorCount()),
-        zap.Bool("mmap_enabled", r.mmapData != nil))
-	
+
+	r.logger.Info("Opened segment for reading",
+		zap.String("path", path),
+		zap.Uint32("cluster_id", segment.GetClusterID()),
+		zap.Uint32("vector_dim", segment.GetVectorDim()),
+		zap.Int("vector_count", segment.GetVectorCount()),
+		zap.Bool("mmap_enabled", r.mmapData != nil))
+
 	return nil
 }
 
@@ -176,50 +176,56 @@ func (r *Reader) enableMMap() error {
 func (r *Reader) ReadVector(vectorID uint64) (*types.Vector, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed {
 		return nil, ErrReaderClosed
 	}
-	
+
 	if r.segment == nil {
 		return nil, ErrSegmentNotOpen
 	}
-	
+
 	// Check cache first
-    if vector, exists := r.cache[vectorID]; exists {
-        if r.metrics != nil { r.metrics.RecordCounter("storage_cache_hits_total", 1, map[string]string{"component":"segment_reader"}) }
-        return vector, nil
-    }
-	
-    if r.metrics != nil { r.metrics.RecordCounter("storage_cache_misses_total", 1, map[string]string{"component":"segment_reader"}) }
-	
+	if vector, exists := r.cache[vectorID]; exists {
+		if r.metrics != nil {
+			r.metrics.RecordCounter("storage_cache_hits_total", 1, map[string]string{"component": "segment_reader"})
+		}
+		return vector, nil
+	}
+
+	if r.metrics != nil {
+		r.metrics.RecordCounter("storage_cache_misses_total", 1, map[string]string{"component": "segment_reader"})
+	}
+
 	// Find index entry
 	entry, exists := r.index[vectorID]
 	if !exists {
 		return nil, ErrVectorNotFound
 	}
-	
+
 	// Read vector from file
 	vector, err := r.readVectorFromEntry(entry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read vector: %w", err)
 	}
-	
+
 	// Update cache
 	if len(r.cache) < r.config.CacheSize {
 		r.cache[vectorID] = vector
 	}
-	
-    // Update metrics
-    if r.metrics != nil { r.metrics.RecordCounter("storage_read_operations_total", 1, map[string]string{"component":"segment_reader"}) }
-	
+
+	// Update metrics
+	if r.metrics != nil {
+		r.metrics.RecordCounter("storage_read_operations_total", 1, map[string]string{"component": "segment_reader"})
+	}
+
 	return vector, nil
 }
 
 // readVectorFromEntry reads a vector from an index entry
 func (r *Reader) readVectorFromEntry(entry *FileIndexEntry) (*types.Vector, error) {
-    var data []byte
-	
+	var data []byte
+
 	if r.mmapData != nil {
 		// Read from memory-mapped data
 		if int(entry.Offset+uint64(entry.Size)) > len(r.mmapData) {
@@ -228,20 +234,24 @@ func (r *Reader) readVectorFromEntry(entry *FileIndexEntry) (*types.Vector, erro
 		data = r.mmapData[entry.Offset : entry.Offset+uint64(entry.Size)]
 	} else {
 		// Read from file
-            if _, err := r.file.Seek(int64(entry.Offset), io.SeekStart); err != nil {
-                if r.metrics != nil { r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_reader","type":"seek_failed"}) }
-                return nil, fmt.Errorf("%w: %v", ErrSeekFailed, err)
-            }
-		
+		if _, err := r.file.Seek(int64(entry.Offset), io.SeekStart); err != nil {
+			if r.metrics != nil {
+				r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_reader", "type": "seek_failed"})
+			}
+			return nil, fmt.Errorf("%w: %v", ErrSeekFailed, err)
+		}
+
 		data = make([]byte, entry.Size)
-            if _, err := io.ReadFull(r.file, data); err != nil {
-                if r.metrics != nil { r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_reader","type":"read_failed"}) }
-                return nil, fmt.Errorf("%w: %v", ErrReadFailed, err)
-            }
+		if _, err := io.ReadFull(r.file, data); err != nil {
+			if r.metrics != nil {
+				r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_reader", "type": "read_failed"})
+			}
+			return nil, fmt.Errorf("%w: %v", ErrReadFailed, err)
+		}
 	}
-	
-    // Parse vector data
-    return r.parseVectorData(data, entry)
+
+	// Parse vector data
+	return r.parseVectorData(data, entry)
 }
 
 // parseVectorData parses vector data from bytes
@@ -249,14 +259,14 @@ func (r *Reader) parseVectorData(data []byte, entry *FileIndexEntry) (*types.Vec
 	if len(data) < 24 {
 		return nil, ErrCorruptedData
 	}
-	
+
 	// Read vector header
-    vectorHeader := &FileVectorHeader{}
+	vectorHeader := &FileVectorHeader{}
 	vectorHeader.VectorID = binary.LittleEndian.Uint64(data[0:8])
 	vectorHeader.Timestamp = int64(binary.LittleEndian.Uint64(data[8:16]))
 	vectorHeader.MetadataSize = binary.LittleEndian.Uint32(data[16:20])
 	vectorHeader.VectorSize = binary.LittleEndian.Uint32(data[20:24])
-	
+
 	// Verify checksum
 	if r.config.EnableChecksum {
 		checksum := crc32.ChecksumIEEE(data[:20])
@@ -264,54 +274,54 @@ func (r *Reader) parseVectorData(data []byte, entry *FileIndexEntry) (*types.Vec
 			return nil, ErrChecksumMismatch
 		}
 	}
-	
+
 	// Validate sizes
 	if vectorHeader.VectorID != entry.VectorID {
 		return nil, ErrCorruptedData
 	}
-	
+
 	expectedSize := 24 + int(vectorHeader.MetadataSize) + int(vectorHeader.VectorSize)
 	if len(data) < expectedSize {
 		return nil, ErrCorruptedData
 	}
-	
+
 	// Read metadata
 	var metadata []byte
 	if vectorHeader.MetadataSize > 0 {
 		metadata = data[24 : 24+vectorHeader.MetadataSize]
 	}
-	
+
 	// Read vector data
 	vectorDataOffset := 24 + vectorHeader.MetadataSize
 	vectorData := data[vectorDataOffset : vectorDataOffset+vectorHeader.VectorSize]
-	
+
 	// Parse vector data
 	if vectorHeader.VectorSize%4 != 0 {
 		return nil, ErrInvalidVectorSize
 	}
-	
+
 	vectorDim := vectorHeader.VectorSize / 4
 	vectorValues := make([]float32, vectorDim)
-	
+
 	for i := 0; i < int(vectorDim); i++ {
 		vectorValues[i] = math.Float32frombits(binary.LittleEndian.Uint32(vectorData[i*4 : (i+1)*4]))
 	}
-	
-    // Create vector
-    vector := &types.Vector{
-        ID:        fmt.Sprintf("%d", vectorHeader.VectorID),
-        Data:      vectorValues,
-        Timestamp: vectorHeader.Timestamp,
-    }
-	
+
+	// Create vector
+	vector := &types.Vector{
+		ID:        fmt.Sprintf("%d", vectorHeader.VectorID),
+		Data:      vectorValues,
+		Timestamp: vectorHeader.Timestamp,
+	}
+
 	// Parse metadata if present
-    if len(metadata) > 0 {
-        var md map[string]interface{}
-        if err := json.Unmarshal(metadata, &md); err == nil {
-            vector.Metadata = md
-        }
-    }
-	
+	if len(metadata) > 0 {
+		var md map[string]interface{}
+		if err := json.Unmarshal(metadata, &md); err == nil {
+			vector.Metadata = md
+		}
+	}
+
 	return vector, nil
 }
 
@@ -319,17 +329,17 @@ func (r *Reader) parseVectorData(data []byte, entry *FileIndexEntry) (*types.Vec
 func (r *Reader) ReadVectors(vectorIDs []uint64) ([]*types.Vector, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed {
 		return nil, ErrReaderClosed
 	}
-	
+
 	if r.segment == nil {
 		return nil, ErrSegmentNotOpen
 	}
-	
+
 	vectors := make([]*types.Vector, 0, len(vectorIDs))
-	
+
 	for _, vectorID := range vectorIDs {
 		vector, err := r.ReadVector(vectorID)
 		if err != nil {
@@ -340,7 +350,7 @@ func (r *Reader) ReadVectors(vectorIDs []uint64) ([]*types.Vector, error) {
 		}
 		vectors = append(vectors, vector)
 	}
-	
+
 	return vectors, nil
 }
 
@@ -348,15 +358,15 @@ func (r *Reader) ReadVectors(vectorIDs []uint64) ([]*types.Vector, error) {
 func (r *Reader) ReadAllVectors() ([]*types.Vector, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed {
 		return nil, ErrReaderClosed
 	}
-	
+
 	if r.segment == nil {
 		return nil, ErrSegmentNotOpen
 	}
-	
+
 	return r.segment.GetVectors(), nil
 }
 
@@ -364,11 +374,11 @@ func (r *Reader) ReadAllVectors() ([]*types.Vector, error) {
 func (r *Reader) HasVector(vectorID uint64) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed || r.segment == nil {
 		return false
 	}
-	
+
 	_, exists := r.index[vectorID]
 	return exists
 }
@@ -377,16 +387,16 @@ func (r *Reader) HasVector(vectorID uint64) bool {
 func (r *Reader) GetVectorIDs() []uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed || r.segment == nil {
 		return nil
 	}
-	
+
 	ids := make([]uint64, 0, len(r.index))
 	for id := range r.index {
 		ids = append(ids, id)
 	}
-	
+
 	return ids
 }
 
@@ -394,7 +404,7 @@ func (r *Reader) GetVectorIDs() []uint64 {
 func (r *Reader) GetVectorCount() int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.segment == nil {
 		return 0
 	}
@@ -406,45 +416,45 @@ func (r *Reader) Prefetch(vectorID uint64) error {
 	if !r.config.EnablePrefetch {
 		return nil
 	}
-	
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed || r.segment == nil {
 		return nil
 	}
-	
+
 	// Find the position of the vector in the index
-    var targetIndex int
+	var targetIndex int
 	found := false
-	
-    for i, entry := range r.segment.index {
-        if entry.VectorID == vectorID {
-            targetIndex = i
-            found = true
-            break
-        }
-    }
-	
+
+	for i, entry := range r.segment.index {
+		if entry.VectorID == vectorID {
+			targetIndex = i
+			found = true
+			break
+		}
+	}
+
 	if !found {
 		return nil
 	}
-	
-    // Prefetch vectors around the target
-    startIndex := max(0, targetIndex-r.config.PrefetchDistance)
-    endIndex := min(len(r.segment.index), targetIndex+r.config.PrefetchDistance+1)
-	
+
+	// Prefetch vectors around the target
+	startIndex := max(0, targetIndex-r.config.PrefetchDistance)
+	endIndex := min(len(r.segment.index), targetIndex+r.config.PrefetchDistance+1)
+
 	for i := startIndex; i < endIndex; i++ {
 		entry := r.segment.index[i]
-            if _, exists := r.cache[entry.VectorID]; !exists {
-            if _, err := r.readVectorFromEntry(entry); err == nil {
-                if len(r.cache) < r.config.CacheSize {
-                    r.cache[entry.VectorID] = r.segment.vectors[entry.VectorID]
-                }
-            }
-            }
+		if _, exists := r.cache[entry.VectorID]; !exists {
+			if _, err := r.readVectorFromEntry(entry); err == nil {
+				if len(r.cache) < r.config.CacheSize {
+					r.cache[entry.VectorID] = r.segment.vectors[entry.VectorID]
+				}
+			}
+		}
 	}
-	
+
 	return nil
 }
 
@@ -452,36 +462,38 @@ func (r *Reader) Prefetch(vectorID uint64) error {
 func (r *Reader) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	
+
 	if r.closed {
 		return nil
 	}
-	
+
 	// Close file
-        if r.file != nil {
-            if err := r.file.Close(); err != nil {
-                if r.metrics != nil { r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_reader","type":"close_failed"}) }
-                r.logger.Error("Failed to close segment file", zap.Error(err))
-            }
-        }
-	
+	if r.file != nil {
+		if err := r.file.Close(); err != nil {
+			if r.metrics != nil {
+				r.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_reader", "type": "close_failed"})
+			}
+			r.logger.Error("Failed to close segment file", zap.Error(err))
+		}
+	}
+
 	// Close all open files
 	for path, file := range r.openFiles {
-            if err := file.Close(); err != nil {
-                r.logger.Error("Failed to close file", zap.String("path", path), zap.Error(err))
-            }
+		if err := file.Close(); err != nil {
+			r.logger.Error("Failed to close file", zap.String("path", path), zap.Error(err))
+		}
 	}
-	
+
 	// Clear memory mapping
 	if r.mmapData != nil {
 		// This would unmap the memory
 		r.mmapData = nil
 	}
-	
+
 	r.closed = true
-	
-    r.logger.Info("Closed segment reader", zap.String("path", r.path))
-	
+
+	r.logger.Info("Closed segment reader", zap.String("path", r.path))
+
 	return nil
 }
 
@@ -489,7 +501,7 @@ func (r *Reader) Close() error {
 func (r *Reader) GetSegment() *FileSegment {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	return r.segment
 }
 
@@ -497,7 +509,7 @@ func (r *Reader) GetSegment() *FileSegment {
 func (r *Reader) GetPath() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	return r.path
 }
 
@@ -505,7 +517,7 @@ func (r *Reader) GetPath() string {
 func (r *Reader) IsClosed() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	return r.closed
 }
 
@@ -513,7 +525,7 @@ func (r *Reader) IsClosed() bool {
 func (r *Reader) GetConfig() *ReaderConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	// Return a copy of the config
 	config := *r.config
 	return &config
@@ -523,25 +535,25 @@ func (r *Reader) GetConfig() *ReaderConfig {
 func (r *Reader) UpdateConfig(config *ReaderConfig) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	
+
 	if r.closed {
 		return ErrReaderClosed
 	}
-	
+
 	r.config = config
-	
+
 	// Update read buffer size if needed
 	if config.ReadBufferSize != len(r.readBuffer) {
 		r.readBuffer = make([]byte, config.ReadBufferSize)
 	}
-	
+
 	// Clear cache if size changed
 	if config.CacheSize != len(r.cache) {
 		r.cache = make(map[uint64]*types.Vector)
 	}
-	
-    r.logger.Info("Updated reader configuration", zap.Any("config", config))
-	
+
+	r.logger.Info("Updated reader configuration", zap.Any("config", config))
+
 	return nil
 }
 
@@ -549,7 +561,7 @@ func (r *Reader) UpdateConfig(config *ReaderConfig) error {
 func (r *Reader) GetStats() map[string]interface{} {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	stats := make(map[string]interface{})
 	stats["closed"] = r.closed
 	stats["cache_size"] = len(r.cache)
@@ -559,7 +571,7 @@ func (r *Reader) GetStats() map[string]interface{} {
 	stats["max_open_files"] = r.config.MaxOpenFiles
 	stats["mmap_enabled"] = r.mmapData != nil
 	stats["read_buffer_size"] = len(r.readBuffer)
-	
+
 	if r.segment != nil {
 		stats["vector_count"] = r.segment.GetVectorCount()
 		stats["cluster_id"] = r.segment.GetClusterID()
@@ -567,7 +579,7 @@ func (r *Reader) GetStats() map[string]interface{} {
 		stats["segment_size"] = r.segment.GetSize()
 		stats["segment_readonly"] = r.segment.IsReadOnly()
 	}
-	
+
 	return stats
 }
 
@@ -575,7 +587,7 @@ func (r *Reader) GetStats() map[string]interface{} {
 func (r *Reader) ClearCache() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	
+
 	r.cache = make(map[uint64]*types.Vector)
 }
 
@@ -583,13 +595,13 @@ func (r *Reader) ClearCache() {
 func (r *Reader) GetCacheInfo() map[string]interface{} {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	info := make(map[string]interface{})
 	info["size"] = len(r.cache)
 	info["max_size"] = r.config.CacheSize
 	info["usage"] = float64(len(r.cache)) / float64(r.config.CacheSize) * 100
 	info["enabled"] = r.config.CacheSize > 0
-	
+
 	return info
 }
 
@@ -597,25 +609,25 @@ func (r *Reader) GetCacheInfo() map[string]interface{} {
 func (r *Reader) Validate() error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	if r.closed {
 		return ErrReaderClosed
 	}
-	
+
 	if r.segment == nil {
 		return ErrSegmentNotOpen
 	}
-	
+
 	// Validate segment
 	if err := r.segment.Validate(); err != nil {
 		return fmt.Errorf("segment validation failed: %w", err)
 	}
-	
+
 	// Validate index consistency
 	if len(r.index) != len(r.segment.index) {
 		return ErrCorruptedIndex
 	}
-	
+
 	for vectorID, entry := range r.index {
 		if _, exists := r.segment.vectors[vectorID]; !exists {
 			return ErrCorruptedIndex
@@ -624,7 +636,7 @@ func (r *Reader) Validate() error {
 			return ErrCorruptedIndex
 		}
 	}
-	
+
 	return nil
 }
 

--- a/internal/storage/segment/segment.go
+++ b/internal/storage/segment/segment.go
@@ -1,38 +1,38 @@
-// Package segment provides segment functionality for VexDB
+// Package segment provides segment functionality for VxDB
 package segment
 
 import (
-    "context"
-    "encoding/binary"
-    "fmt"
-    "io"
-    "os"
-    "path/filepath"
-    "sync"
-    "time"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
-	"vexdb/internal/config"
-    "vexdb/internal/metrics"
-	"vexdb/internal/storage/compression"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/compression"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )
 
 // Segment represents a single segment in the storage system
 type Segment struct {
-	info        *SegmentInfo
-	config      *config.Config
-	logger      *zap.Logger
-	metrics     *metrics.Collector
-	compressor  *compression.Compressor
-	
-	file        *os.File
-	writer      *Writer
-	reader      *Reader
-	
-	mu          sync.RWMutex
-	closed      bool
+	info       *SegmentInfo
+	config     *config.Config
+	logger     *zap.Logger
+	metrics    *metrics.Collector
+	compressor *compression.Compressor
+
+	file   *os.File
+	writer *Writer
+	reader *Reader
+
+	mu     sync.RWMutex
+	closed bool
 }
 
 // NewSegment creates a new segment
@@ -62,7 +62,7 @@ func NewSegment(info *SegmentInfo, cfg *config.Config, logger *zap.Logger, metri
 // initializeFile initializes the segment file
 func (s *Segment) initializeFile() error {
 	// Create segment directory if it doesn't exist
-    segmentDir := filepath.Join("./data", "segments", s.info.ClusterIDString())
+	segmentDir := filepath.Join("./data", "segments", s.info.ClusterIDString())
 	if err := os.MkdirAll(segmentDir, 0755); err != nil {
 		return fmt.Errorf("failed to create segment directory: %w", err)
 	}
@@ -97,13 +97,13 @@ func (s *Segment) initializeComponents() error {
 	var err error
 
 	// Initialize writer
-    s.writer, err = NewWriter(s.config, s.logger, s.metrics, s.compressor, s.file)
+	s.writer, err = NewWriter(s.config, s.logger, s.metrics, s.compressor, s.file)
 	if err != nil {
 		return err
 	}
 
 	// Initialize reader
-    s.reader, err = NewReader(s.config, s.logger, s.metrics, s.compressor, s.file)
+	s.reader, err = NewReader(s.config, s.logger, s.metrics, s.compressor, s.file)
 	if err != nil {
 		return err
 	}
@@ -113,16 +113,16 @@ func (s *Segment) initializeComponents() error {
 
 // writeHeader writes the segment header to the file
 func (s *Segment) writeHeader() error {
-    header := &SegmentHeader{
-        Magic:      SegmentMagic,
-        Version:    SegmentVersion,
-        ClusterID:  s.info.ClusterID,
-        SegmentID:  s.info.ID,
-        Status:     string(s.info.Status),
-        VectorSize: 0,
-        CreatedAt:  s.info.CreatedAt,
-        UpdatedAt:  s.info.UpdatedAt,
-    }
+	header := &SegmentHeader{
+		Magic:      SegmentMagic,
+		Version:    SegmentVersion,
+		ClusterID:  s.info.ClusterID,
+		SegmentID:  s.info.ID,
+		Status:     string(s.info.Status),
+		VectorSize: 0,
+		CreatedAt:  s.info.CreatedAt,
+		UpdatedAt:  s.info.UpdatedAt,
+	}
 
 	// Write header at the beginning of the file
 	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
@@ -156,7 +156,7 @@ func (s *Segment) readHeader() error {
 
 	// Update segment info from header
 	s.info.ClusterID = header.ClusterID
-    s.info.Status = SegmentStatus(header.Status)
+	s.info.Status = SegmentStatus(header.Status)
 	s.info.CreatedAt = header.CreatedAt
 	s.info.UpdatedAt = header.UpdatedAt
 
@@ -212,16 +212,18 @@ func (s *Segment) SearchVectors(ctx context.Context, query *types.Vector, k int)
 		return nil, err
 	}
 
-    // Perform linear search (euclidean by default)
-    results := make([]*types.SearchResult, 0, len(vectors))
-    for _, vector := range vectors {
-        distance, err := query.Distance(vector, "euclidean")
-        if err != nil { continue }
-        results = append(results, &types.SearchResult{
-            Vector:   vector,
-            Distance: distance,
-        })
-    }
+	// Perform linear search (euclidean by default)
+	results := make([]*types.SearchResult, 0, len(vectors))
+	for _, vector := range vectors {
+		distance, err := query.Distance(vector, "euclidean")
+		if err != nil {
+			continue
+		}
+		results = append(results, &types.SearchResult{
+			Vector:   vector,
+			Distance: distance,
+		})
+	}
 
 	// Sort by distance (ascending)
 	types.SortSearchResults(results)
@@ -292,14 +294,14 @@ func (s *Segment) GetStatus() *types.SegmentStatus {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-    return &types.SegmentStatus{
-        ID:          s.info.ID,
-        ClusterID:   s.info.ClusterID,
-        Status:      string(s.info.Status),
-        VectorCount: s.info.VectorCount,
-        CreatedAt:   time.Unix(int64(s.info.CreatedAt), 0),
-        UpdatedAt:   time.Unix(int64(s.info.UpdatedAt), 0),
-    }
+	return &types.SegmentStatus{
+		ID:          s.info.ID,
+		ClusterID:   s.info.ClusterID,
+		Status:      string(s.info.Status),
+		VectorCount: s.info.VectorCount,
+		CreatedAt:   time.Unix(int64(s.info.CreatedAt), 0),
+		UpdatedAt:   time.Unix(int64(s.info.UpdatedAt), 0),
+	}
 }
 
 // Flush flushes any pending data to disk

--- a/internal/storage/segment/writer.go
+++ b/internal/storage/segment/writer.go
@@ -1,31 +1,31 @@
 package segment
 
 import (
-    "encoding/binary"
-    "errors"
-    "fmt"
-    "hash/crc32"
-    "math"
-    "os"
-    "path/filepath"
-    "sync"
-    "time"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
-    "vexdb/internal/config"
-    "vexdb/internal/metrics"
-    "vexdb/internal/storage/compression"
-    "vexdb/internal/types"
-    "go.uber.org/zap"
+	"go.uber.org/zap"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/compression"
+	"vxdb/internal/types"
 )
 
 var (
-    ErrSegmentExists    = errors.New("segment already exists")
-    ErrWriterClosed     = errors.New("writer is closed")
-    ErrInvalidVector    = errors.New("invalid vector")
-    ErrWriteFailed      = errors.New("write failed")
-    ErrFlushFailed      = errors.New("flush failed")
-    ErrSyncFailed       = errors.New("sync failed")
-	ErrCloseFailed      = errors.New("close failed")
+	ErrSegmentExists = errors.New("segment already exists")
+	ErrWriterClosed  = errors.New("writer is closed")
+	ErrInvalidVector = errors.New("invalid vector")
+	ErrWriteFailed   = errors.New("write failed")
+	ErrFlushFailed   = errors.New("flush failed")
+	ErrSyncFailed    = errors.New("sync failed")
+	ErrCloseFailed   = errors.New("close failed")
 )
 
 // WriterConfig represents the configuration for the segment writer
@@ -56,75 +56,75 @@ func DefaultWriterConfig() *WriterConfig {
 
 // Writer represents a segment writer
 type Writer struct {
-    config      *WriterConfig
-    segment     *FileSegment
+	config      *WriterConfig
+	segment     *FileSegment
 	file        *os.File
 	path        string
 	mu          sync.RWMutex
 	closed      bool
 	flushTimer  *time.Timer
-    logger      *zap.Logger
-    metrics     *metrics.Collector
+	logger      *zap.Logger
+	metrics     *metrics.Collector
 	writeBuffer []byte
 	bufferPos   int
 }
 
 // NewWriter creates a new segment writer
 func NewWriter(cfg *config.Config, logger *zap.Logger, metrics *metrics.Collector, _ *compression.Compressor, _ *os.File) (*Writer, error) {
-    writerConfig := DefaultWriterConfig()
-    // ignore cfg overrides for now
-	
+	writerConfig := DefaultWriterConfig()
+	// ignore cfg overrides for now
+
 	// Ensure data directory exists
 	if err := os.MkdirAll(writerConfig.DataDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create data directory: %w", err)
 	}
-	
+
 	return &Writer{
 		config:      writerConfig,
-            logger:      logger,
-            metrics:     metrics,
-            writeBuffer: make([]byte, writerConfig.BufferSize),
-        }, nil
+		logger:      logger,
+		metrics:     metrics,
+		writeBuffer: make([]byte, writerConfig.BufferSize),
+	}, nil
 }
 
 // CreateSegment creates a new segment for writing
 func (w *Writer) CreateSegment(clusterID uint32, vectorDim uint32) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	if w.segment != nil {
 		return ErrSegmentExists
 	}
-	
+
 	// Generate segment path
 	segmentID := time.Now().UnixNano()
-	path := filepath.Join(w.config.DataDir, fmt.Sprintf("segment_%d_%d.vex", clusterID, segmentID))
-	
+	path := filepath.Join(w.config.DataDir, fmt.Sprintf("segment_%d_%d.vx", clusterID, segmentID))
+
 	// Create new segment
-    w.segment = NewFileSegment(path, vectorDim, clusterID, w.config.MaxVectorsPerSegment)
+	w.segment = NewFileSegment(path, vectorDim, clusterID, w.config.MaxVectorsPerSegment)
 	w.path = path
-	
+
 	// Create file
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create segment file: %w", err)
 	}
-	
+
 	w.file = file
-	
+
 	// Start flush timer
 	w.startFlushTimer()
-	
-    w.logger.Info("Created new segment",
-        zap.String("path", path),
-        zap.Uint32("cluster_id", clusterID),
-        zap.Uint32("vector_dim", vectorDim),
-        zap.Int("max_vectors", w.config.MaxVectorsPerSegment))
-	
+
+	w.logger.Info("Created new segment",
+		zap.String("path", path),
+		zap.Uint32("cluster_id", clusterID),
+		zap.Uint32("vector_dim", vectorDim),
+		zap.Int("max_vectors", w.config.MaxVectorsPerSegment))
+
 	return nil
 }
 
@@ -132,40 +132,40 @@ func (w *Writer) CreateSegment(clusterID uint32, vectorDim uint32) error {
 func (w *Writer) OpenSegment(path string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	if w.segment != nil {
 		return ErrSegmentExists
 	}
-	
+
 	// Load segment
-    segment, err := LoadFileSegment(path)
+	segment, err := LoadFileSegment(path)
 	if err != nil {
 		return fmt.Errorf("failed to load segment: %w", err)
 	}
-	
+
 	// Open file
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open segment file: %w", err)
 	}
-	
+
 	w.segment = segment
 	w.path = path
 	w.file = file
-	
+
 	// Start flush timer
 	w.startFlushTimer()
-	
-    w.logger.Info("Opened existing segment",
-        zap.String("path", path),
-        zap.Uint32("cluster_id", segment.GetClusterID()),
-        zap.Uint32("vector_dim", segment.GetVectorDim()),
-        zap.Int("vector_count", segment.GetVectorCount()))
-	
+
+	w.logger.Info("Opened existing segment",
+		zap.String("path", path),
+		zap.Uint32("cluster_id", segment.GetClusterID()),
+		zap.Uint32("vector_dim", segment.GetVectorDim()),
+		zap.Int("vector_count", segment.GetVectorCount()))
+
 	return nil
 }
 
@@ -173,122 +173,124 @@ func (w *Writer) OpenSegment(path string) error {
 func (w *Writer) WriteVector(vector *types.Vector) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	if w.segment == nil {
 		return ErrSegmentNotFound
 	}
-	
+
 	if w.segment.IsFull() {
 		return ErrSegmentFull
 	}
-	
+
 	// Validate vector
 	if err := vector.Validate(); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidVector, err)
 	}
-	
+
 	// Check vector dimension
 	if len(vector.Data) != int(w.segment.GetVectorDim()) {
 		return fmt.Errorf("%w: vector dimension mismatch", ErrInvalidVector)
 	}
-	
+
 	// Add vector to segment
 	if err := w.segment.AddVector(vector); err != nil {
 		return fmt.Errorf("failed to add vector to segment: %w", err)
 	}
-	
+
 	// Write vector to buffer
 	if err := w.writeVectorToBuffer(vector); err != nil {
 		return fmt.Errorf("failed to write vector to buffer: %w", err)
 	}
-	
-        // Update metrics
-        if w.metrics != nil {
-            w.metrics.RecordCounter("storage_write_operations_total", 1, map[string]string{"component":"segment_writer"})
-            w.metrics.RecordCounter("storage_vectors_total", 1, map[string]string{"cluster": fmt.Sprintf("%d", w.segment.GetClusterID())})
-        }
-	
+
+	// Update metrics
+	if w.metrics != nil {
+		w.metrics.RecordCounter("storage_write_operations_total", 1, map[string]string{"component": "segment_writer"})
+		w.metrics.RecordCounter("storage_vectors_total", 1, map[string]string{"cluster": fmt.Sprintf("%d", w.segment.GetClusterID())})
+	}
+
 	// Check if buffer needs to be flushed
 	if w.bufferPos >= len(w.writeBuffer) {
 		if err := w.flushBuffer(); err != nil {
 			return fmt.Errorf("failed to flush buffer: %w", err)
 		}
 	}
-	
+
 	// Sync if configured
 	if w.config.SyncOnWrite {
-            if err := w.file.Sync(); err != nil {
-                if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"sync_failed"}) }
-                return fmt.Errorf("%w: %v", ErrSyncFailed, err)
-            }
+		if err := w.file.Sync(); err != nil {
+			if w.metrics != nil {
+				w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "sync_failed"})
+			}
+			return fmt.Errorf("%w: %v", ErrSyncFailed, err)
+		}
 	}
-	
+
 	return nil
 }
 
 // writeVectorToBuffer writes a vector to the write buffer
 func (w *Writer) writeVectorToBuffer(vector *types.Vector) error {
 	// Serialize vector header
-    vectorHeader := &FileVectorHeader{
-        VectorID:     idToU64(vector.ID),
-        Timestamp:    vector.Timestamp,
-        VectorSize:   uint32(len(vector.Data) * 4), // float32 = 4 bytes
-        Flags:        0,
-    }
-	
+	vectorHeader := &FileVectorHeader{
+		VectorID:   idToU64(vector.ID),
+		Timestamp:  vector.Timestamp,
+		VectorSize: uint32(len(vector.Data) * 4), // float32 = 4 bytes
+		Flags:      0,
+	}
+
 	var metadata []byte
-    if vector.Metadata != nil {
-        metadata = encodeMetadata(vector.Metadata)
-        vectorHeader.MetadataSize = uint32(len(metadata))
-    }
-	
+	if vector.Metadata != nil {
+		metadata = encodeMetadata(vector.Metadata)
+		vectorHeader.MetadataSize = uint32(len(metadata))
+	}
+
 	// Check buffer capacity
 	headerSize := 24
 	metadataSize := int(vectorHeader.MetadataSize)
 	vectorSize := len(vector.Data) * 4
 	totalSize := headerSize + metadataSize + vectorSize
-	
-    if w.bufferPos+totalSize > len(w.writeBuffer) {
+
+	if w.bufferPos+totalSize > len(w.writeBuffer) {
 		if err := w.flushBuffer(); err != nil {
 			return err
 		}
-		
+
 		// If still not enough space, write directly
-            if totalSize > len(w.writeBuffer) {
-                return w.writeVectorDirectly(vector, vectorHeader, metadata)
-            }
+		if totalSize > len(w.writeBuffer) {
+			return w.writeVectorDirectly(vector, vectorHeader, metadata)
+		}
 	}
-	
+
 	// Write header to buffer
 	binary.LittleEndian.PutUint64(w.writeBuffer[w.bufferPos:w.bufferPos+8], vectorHeader.VectorID)
 	binary.LittleEndian.PutUint64(w.writeBuffer[w.bufferPos+8:w.bufferPos+16], uint64(vectorHeader.Timestamp))
 	binary.LittleEndian.PutUint32(w.writeBuffer[w.bufferPos+16:w.bufferPos+20], vectorHeader.MetadataSize)
 	binary.LittleEndian.PutUint32(w.writeBuffer[w.bufferPos+20:w.bufferPos+24], vectorHeader.VectorSize)
-	
+
 	// Calculate and write checksum
 	if w.config.EnableChecksum {
 		checksum := crc32.ChecksumIEEE(w.writeBuffer[w.bufferPos : w.bufferPos+20])
 		binary.LittleEndian.PutUint32(w.writeBuffer[w.bufferPos+20:w.bufferPos+24], checksum)
 	}
-	
+
 	w.bufferPos += 24
-	
+
 	// Write metadata to buffer
 	if metadataSize > 0 {
 		copy(w.writeBuffer[w.bufferPos:w.bufferPos+metadataSize], metadata)
 		w.bufferPos += metadataSize
 	}
-	
+
 	// Write vector data to buffer
 	for i, val := range vector.Data {
 		binary.LittleEndian.PutUint32(w.writeBuffer[w.bufferPos+i*4:w.bufferPos+(i+1)*4], math.Float32bits(val))
 	}
 	w.bufferPos += vectorSize
-	
+
 	return nil
 }
 
@@ -296,35 +298,37 @@ func (w *Writer) writeVectorToBuffer(vector *types.Vector) error {
 func (w *Writer) writeVectorDirectly(vector *types.Vector, vectorHeader *FileVectorHeader, metadata []byte) error {
 	// Create temporary buffer for this vector
 	buf := make([]byte, 24+len(metadata)+len(vector.Data)*4)
-	
+
 	// Write header
 	binary.LittleEndian.PutUint64(buf[0:8], vectorHeader.VectorID)
 	binary.LittleEndian.PutUint64(buf[8:16], uint64(vectorHeader.Timestamp))
 	binary.LittleEndian.PutUint32(buf[16:20], vectorHeader.MetadataSize)
 	binary.LittleEndian.PutUint32(buf[20:24], vectorHeader.VectorSize)
-	
+
 	// Calculate and write checksum
 	if w.config.EnableChecksum {
 		checksum := crc32.ChecksumIEEE(buf[:20])
 		binary.LittleEndian.PutUint32(buf[20:24], checksum)
 	}
-	
+
 	// Write metadata
 	if len(metadata) > 0 {
 		copy(buf[24:24+len(metadata)], metadata)
 	}
-	
+
 	// Write vector data
 	for i, val := range vector.Data {
 		binary.LittleEndian.PutUint32(buf[24+len(metadata)+i*4:24+len(metadata)+(i+1)*4], math.Float32bits(val))
 	}
-	
+
 	// Write to file
-    if _, err := w.file.Write(buf); err != nil {
-        if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"write_failed"}) }
-        return fmt.Errorf("%w: %v", ErrWriteFailed, err)
-    }
-	
+	if _, err := w.file.Write(buf); err != nil {
+		if w.metrics != nil {
+			w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "write_failed"})
+		}
+		return fmt.Errorf("%w: %v", ErrWriteFailed, err)
+	}
+
 	return nil
 }
 
@@ -332,11 +336,11 @@ func (w *Writer) writeVectorDirectly(vector *types.Vector, vectorHeader *FileVec
 func (w *Writer) Flush() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	return w.flushBuffer()
 }
 
@@ -345,16 +349,18 @@ func (w *Writer) flushBuffer() error {
 	if w.bufferPos == 0 {
 		return nil
 	}
-	
+
 	// Write buffer to file
-    if _, err := w.file.Write(w.writeBuffer[:w.bufferPos]); err != nil {
-        if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"flush_failed"}) }
-        return fmt.Errorf("%w: %v", ErrFlushFailed, err)
-    }
-	
+	if _, err := w.file.Write(w.writeBuffer[:w.bufferPos]); err != nil {
+		if w.metrics != nil {
+			w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "flush_failed"})
+		}
+		return fmt.Errorf("%w: %v", ErrFlushFailed, err)
+	}
+
 	// Reset buffer position
 	w.bufferPos = 0
-	
+
 	return nil
 }
 
@@ -362,20 +368,22 @@ func (w *Writer) flushBuffer() error {
 func (w *Writer) Sync() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	if w.file == nil {
 		return nil
 	}
-	
-    if err := w.file.Sync(); err != nil {
-        if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"sync_failed"}) }
-        return fmt.Errorf("%w: %v", ErrSyncFailed, err)
-    }
-	
+
+	if err := w.file.Sync(); err != nil {
+		if w.metrics != nil {
+			w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "sync_failed"})
+		}
+		return fmt.Errorf("%w: %v", ErrSyncFailed, err)
+	}
+
 	return nil
 }
 
@@ -383,39 +391,41 @@ func (w *Writer) Sync() error {
 func (w *Writer) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return nil
 	}
-	
+
 	// Stop flush timer
 	if w.flushTimer != nil {
 		w.flushTimer.Stop()
 	}
-	
+
 	// Flush remaining data
-    if err := w.flushBuffer(); err != nil {
-        w.logger.Error("Failed to flush buffer on close", zap.Error(err))
-    }
-	
+	if err := w.flushBuffer(); err != nil {
+		w.logger.Error("Failed to flush buffer on close", zap.Error(err))
+	}
+
 	// Close file
-    if w.file != nil {
-        if err := w.file.Close(); err != nil {
-            if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"close_failed"}) }
-            w.logger.Error("Failed to close segment file", zap.Error(err))
-            return fmt.Errorf("%w: %v", ErrCloseFailed, err)
-        }
-    }
-	
+	if w.file != nil {
+		if err := w.file.Close(); err != nil {
+			if w.metrics != nil {
+				w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "close_failed"})
+			}
+			w.logger.Error("Failed to close segment file", zap.Error(err))
+			return fmt.Errorf("%w: %v", ErrCloseFailed, err)
+		}
+	}
+
 	// Mark segment as read-only
 	if w.segment != nil {
 		w.segment.SetReadOnly()
 	}
-	
+
 	w.closed = true
-	
-    w.logger.Info("Closed segment writer", zap.String("path", w.path))
-	
+
+	w.logger.Info("Closed segment writer", zap.String("path", w.path))
+
 	return nil
 }
 
@@ -424,12 +434,12 @@ func (w *Writer) startFlushTimer() {
 	if w.flushTimer != nil {
 		w.flushTimer.Stop()
 	}
-	
+
 	w.flushTimer = time.AfterFunc(w.config.FlushInterval, func() {
-        if err := w.Flush(); err != nil {
-            w.logger.Error("Failed to auto-flush segment", zap.Error(err))
-        }
-		
+		if err := w.Flush(); err != nil {
+			w.logger.Error("Failed to auto-flush segment", zap.Error(err))
+		}
+
 		// Restart timer
 		w.startFlushTimer()
 	})
@@ -439,7 +449,7 @@ func (w *Writer) startFlushTimer() {
 func (w *Writer) GetSegment() *FileSegment {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	return w.segment
 }
 
@@ -447,7 +457,7 @@ func (w *Writer) GetSegment() *FileSegment {
 func (w *Writer) GetPath() string {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	return w.path
 }
 
@@ -455,7 +465,7 @@ func (w *Writer) GetPath() string {
 func (w *Writer) IsClosed() bool {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	return w.closed
 }
 
@@ -463,7 +473,7 @@ func (w *Writer) IsClosed() bool {
 func (w *Writer) GetVectorCount() int {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	if w.segment == nil {
 		return 0
 	}
@@ -474,7 +484,7 @@ func (w *Writer) GetVectorCount() int {
 func (w *Writer) IsFull() bool {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	if w.segment == nil {
 		return false
 	}
@@ -485,7 +495,7 @@ func (w *Writer) IsFull() bool {
 func (w *Writer) GetConfig() *WriterConfig {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	// Return a copy of the config
 	config := *w.config
 	return &config
@@ -495,13 +505,13 @@ func (w *Writer) GetConfig() *WriterConfig {
 func (w *Writer) UpdateConfig(config *WriterConfig) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	w.config = config
-	
+
 	// Update buffer size if needed
 	if config.BufferSize != len(w.writeBuffer) {
 		newBuffer := make([]byte, config.BufferSize)
@@ -510,12 +520,12 @@ func (w *Writer) UpdateConfig(config *WriterConfig) error {
 		}
 		w.writeBuffer = newBuffer
 	}
-	
+
 	// Restart flush timer with new interval
 	w.startFlushTimer()
-	
-    w.logger.Info("Updated writer configuration", zap.Any("config", config))
-	
+
+	w.logger.Info("Updated writer configuration", zap.Any("config", config))
+
 	return nil
 }
 
@@ -523,25 +533,27 @@ func (w *Writer) UpdateConfig(config *WriterConfig) error {
 func (w *Writer) Rotate(clusterID uint32, vectorDim uint32) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	// Close current segment
 	if w.segment != nil {
 		if err := w.flushBuffer(); err != nil {
 			return err
 		}
-		
-            if err := w.file.Close(); err != nil {
-                if w.metrics != nil { w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component":"segment_writer","type":"close_failed"}) }
-                return fmt.Errorf("%w: %v", ErrCloseFailed, err)
-            }
-		
+
+		if err := w.file.Close(); err != nil {
+			if w.metrics != nil {
+				w.metrics.RecordCounter("storage_errors_total", 1, map[string]string{"component": "segment_writer", "type": "close_failed"})
+			}
+			return fmt.Errorf("%w: %v", ErrCloseFailed, err)
+		}
+
 		w.segment.SetReadOnly()
 	}
-	
+
 	// Create new segment
 	return w.CreateSegment(clusterID, vectorDim)
 }
@@ -550,13 +562,13 @@ func (w *Writer) Rotate(clusterID uint32, vectorDim uint32) error {
 func (w *Writer) GetStats() map[string]interface{} {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	stats := make(map[string]interface{})
 	stats["closed"] = w.closed
 	stats["buffer_size"] = len(w.writeBuffer)
 	stats["buffer_pos"] = w.bufferPos
 	stats["buffer_usage"] = float64(w.bufferPos) / float64(len(w.writeBuffer)) * 100
-	
+
 	if w.segment != nil {
 		stats["vector_count"] = w.segment.GetVectorCount()
 		stats["cluster_id"] = w.segment.GetClusterID()
@@ -566,7 +578,7 @@ func (w *Writer) GetStats() map[string]interface{} {
 		stats["segment_dirty"] = w.segment.IsDirty()
 		stats["segment_size"] = w.segment.GetSize()
 	}
-	
+
 	return stats
 }
 
@@ -574,23 +586,23 @@ func (w *Writer) GetStats() map[string]interface{} {
 func (w *Writer) Validate() error {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	if w.closed {
 		return ErrWriterClosed
 	}
-	
+
 	if w.segment == nil {
 		return ErrSegmentNotFound
 	}
-	
+
 	if w.file == nil {
 		return errors.New("file handle is nil")
 	}
-	
+
 	// Validate segment
 	if err := w.segment.Validate(); err != nil {
 		return fmt.Errorf("segment validation failed: %w", err)
 	}
-	
+
 	return nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,4 +1,4 @@
-// Package storage provides the core storage engine functionality for VexDB
+// Package storage provides the core storage engine functionality for VxDB
 package storage
 
 import (
@@ -7,15 +7,15 @@ import (
 	"sync"
 	"time"
 
-	"vexdb/internal/config"
-	"vexdb/internal/metrics"
-	"vexdb/internal/storage/buffer"
-	"vexdb/internal/storage/clusterrange"
-	"vexdb/internal/storage/compression"
-	"vexdb/internal/storage/hashing"
-	"vexdb/internal/storage/search"
-	"vexdb/internal/storage/segment"
-	"vexdb/internal/types"
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/storage/buffer"
+	"vxdb/internal/storage/clusterrange"
+	"vxdb/internal/storage/compression"
+	"vxdb/internal/storage/hashing"
+	"vxdb/internal/storage/search"
+	"vxdb/internal/storage/segment"
+	"vxdb/internal/types"
 
 	"go.uber.org/zap"
 )

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -4,11 +4,11 @@ import "errors"
 
 // Storage-related errors
 var (
-	ErrStorageNotStarted = errors.New("storage not started")
-	ErrSegmentClosed     = errors.New("segment closed")
-	ErrInvalidSegmentFormat = errors.New("invalid segment format")
+	ErrStorageNotStarted         = errors.New("storage not started")
+	ErrSegmentClosed             = errors.New("segment closed")
+	ErrInvalidSegmentFormat      = errors.New("invalid segment format")
 	ErrUnsupportedSegmentVersion = errors.New("unsupported segment version")
-	ErrSearchFailed     = errors.New("search failed")
+	ErrSearchFailed              = errors.New("search failed")
 )
 
 // Buffer-related errors
@@ -27,35 +27,35 @@ var (
 
 // Vector-related errors
 var (
-	ErrVectorNotFound   = errors.New("vector not found")
-	ErrVectorExists     = errors.New("vector already exists")
-	ErrVectorInvalid    = errors.New("vector invalid")
-	ErrVectorTooLarge   = errors.New("vector too large")
+	ErrVectorNotFound = errors.New("vector not found")
+	ErrVectorExists   = errors.New("vector already exists")
+	ErrVectorInvalid  = errors.New("vector invalid")
+	ErrVectorTooLarge = errors.New("vector too large")
 )
 
 // Cluster-related errors
 var (
-	ErrClusterNotFound  = errors.New("cluster not found")
-	ErrClusterExists    = errors.New("cluster already exists")
-	ErrClusterFull      = errors.New("cluster full")
-	ErrNodeNotFound     = errors.New("node not found")
-	ErrNodeExists       = errors.New("node already exists")
-	ErrNodeUnhealthy    = errors.New("node unhealthy")
+	ErrClusterNotFound = errors.New("cluster not found")
+	ErrClusterExists   = errors.New("cluster already exists")
+	ErrClusterFull     = errors.New("cluster full")
+	ErrNodeNotFound    = errors.New("node not found")
+	ErrNodeExists      = errors.New("node already exists")
+	ErrNodeUnhealthy   = errors.New("node unhealthy")
 )
 
 // Configuration-related errors
 var (
-	ErrConfigInvalid    = errors.New("configuration invalid")
-	ErrConfigNotFound   = errors.New("configuration not found")
-	ErrConfigExists     = errors.New("configuration already exists")
+	ErrConfigInvalid  = errors.New("configuration invalid")
+	ErrConfigNotFound = errors.New("configuration not found")
+	ErrConfigExists   = errors.New("configuration already exists")
 )
 
 // Query-related errors
 var (
-	ErrQueryInvalid     = errors.New("query invalid")
-	ErrQueryTimeout     = errors.New("query timeout")
-	ErrQueryCancelled   = errors.New("query cancelled")
-	ErrQueryFailed      = errors.New("query failed")
+	ErrQueryInvalid   = errors.New("query invalid")
+	ErrQueryTimeout   = errors.New("query timeout")
+	ErrQueryCancelled = errors.New("query cancelled")
+	ErrQueryFailed    = errors.New("query failed")
 )
 
 // Metadata-related errors
@@ -67,24 +67,24 @@ var (
 
 // Compression-related errors
 var (
-	ErrCompressionFailed = errors.New("compression failed")
-	ErrDecompressionFailed = errors.New("decompression failed")
+	ErrCompressionFailed       = errors.New("compression failed")
+	ErrDecompressionFailed     = errors.New("decompression failed")
 	ErrCompressionNotSupported = errors.New("compression not supported")
 )
 
 // Hashing-related errors
 var (
-	ErrHashFailed      = errors.New("hash failed")
-	ErrHashInvalid     = errors.New("hash invalid")
-	ErrHashNotFound    = errors.New("hash not found")
+	ErrHashFailed   = errors.New("hash failed")
+	ErrHashInvalid  = errors.New("hash invalid")
+	ErrHashNotFound = errors.New("hash not found")
 )
 
 // Range-related errors
 var (
-	ErrRangeInvalid    = errors.New("range invalid")
-	ErrRangeNotFound   = errors.New("range not found")
-	ErrRangeExists     = errors.New("range already exists")
-	ErrRangeOverlap    = errors.New("range overlap")
+	ErrRangeInvalid  = errors.New("range invalid")
+	ErrRangeNotFound = errors.New("range not found")
+	ErrRangeExists   = errors.New("range already exists")
+	ErrRangeOverlap  = errors.New("range overlap")
 )
 
 // Search-related errors
@@ -98,41 +98,41 @@ var (
 
 // Service-related errors
 var (
-	ErrServiceNotStarted = errors.New("service not started")
-	ErrServiceStopped    = errors.New("service stopped")
-	ErrServiceFailed     = errors.New("service failed")
+	ErrServiceNotStarted  = errors.New("service not started")
+	ErrServiceStopped     = errors.New("service stopped")
+	ErrServiceFailed      = errors.New("service failed")
 	ErrServiceUnavailable = errors.New("service unavailable")
 )
 
 // Network-related errors
 var (
-	ErrNetworkTimeout   = errors.New("network timeout")
+	ErrNetworkTimeout     = errors.New("network timeout")
 	ErrNetworkUnavailable = errors.New("network unavailable")
-	ErrConnectionFailed = errors.New("connection failed")
-	ErrConnectionClosed = errors.New("connection closed")
+	ErrConnectionFailed   = errors.New("connection failed")
+	ErrConnectionClosed   = errors.New("connection closed")
 )
 
 // Authentication-related errors
 var (
-	ErrAuthFailed      = errors.New("authentication failed")
-	ErrAuthInvalid     = errors.New("authentication invalid")
-	ErrAuthExpired     = errors.New("authentication expired")
-	ErrAuthNotFound    = errors.New("authentication not found")
+	ErrAuthFailed   = errors.New("authentication failed")
+	ErrAuthInvalid  = errors.New("authentication invalid")
+	ErrAuthExpired  = errors.New("authentication expired")
+	ErrAuthNotFound = errors.New("authentication not found")
 )
 
 // Authorization-related errors
 var (
-	ErrUnauthorized    = errors.New("unauthorized")
-	ErrForbidden       = errors.New("forbidden")
-	ErrAccessDenied    = errors.New("access denied")
+	ErrUnauthorized     = errors.New("unauthorized")
+	ErrForbidden        = errors.New("forbidden")
+	ErrAccessDenied     = errors.New("access denied")
 	ErrPermissionDenied = errors.New("permission denied")
 )
 
 // Rate limiting-related errors
 var (
 	ErrRateLimitExceeded = errors.New("rate limit exceeded")
-	ErrQuotaExceeded    = errors.New("quota exceeded")
-	ErrThrottled        = errors.New("throttled")
+	ErrQuotaExceeded     = errors.New("quota exceeded")
+	ErrThrottled         = errors.New("throttled")
 )
 
 // Validation-related errors
@@ -149,14 +149,14 @@ var (
 
 // System-related errors
 var (
-	ErrSystemError      = errors.New("system error")
-	ErrInternalError    = errors.New("internal error")
-	ErrNotImplemented   = errors.New("not implemented")
-	ErrNotSupported     = errors.New("not supported")
-	ErrTimeout          = errors.New("timeout")
-	ErrCancelled        = errors.New("cancelled")
-	ErrBusy             = errors.New("busy")
-	ErrUnavailable      = errors.New("unavailable")
-	ErrFailed           = errors.New("failed")
-	ErrUnknown          = errors.New("unknown error")
+	ErrSystemError    = errors.New("system error")
+	ErrInternalError  = errors.New("internal error")
+	ErrNotImplemented = errors.New("not implemented")
+	ErrNotSupported   = errors.New("not supported")
+	ErrTimeout        = errors.New("timeout")
+	ErrCancelled      = errors.New("cancelled")
+	ErrBusy           = errors.New("busy")
+	ErrUnavailable    = errors.New("unavailable")
+	ErrFailed         = errors.New("failed")
+	ErrUnknown        = errors.New("unknown error")
 )

--- a/internal/types/metadata.go
+++ b/internal/types/metadata.go
@@ -13,19 +13,19 @@ import (
 type Metadata struct {
 	Fields    map[string]interface{} `json:"fields" yaml:"fields"`
 	Schema    *MetadataSchema        `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Timestamp int64                 `json:"timestamp" yaml:"timestamp"`
-	Version   int32                 `json:"version" yaml:"version"`
+	Timestamp int64                  `json:"timestamp" yaml:"timestamp"`
+	Version   int32                  `json:"version" yaml:"version"`
 }
 
 // MetadataSchema defines the schema for metadata validation
 type MetadataSchema struct {
 	Fields map[string]MetadataField `json:"fields" yaml:"fields"`
-	Strict bool                    `json:"strict" yaml:"strict"` // Strict validation mode
+	Strict bool                     `json:"strict" yaml:"strict"` // Strict validation mode
 }
 
 // MetadataField defines a single field in the metadata schema
 type MetadataField struct {
-	Type        string      `json:"type" yaml:"type"`        // "string", "int", "float", "bool", "datetime", "array", "object"
+	Type        string      `json:"type" yaml:"type"` // "string", "int", "float", "bool", "datetime", "array", "object"
 	Required    bool        `json:"required" yaml:"required"`
 	Default     interface{} `json:"default,omitempty" yaml:"default,omitempty"`
 	Min         interface{} `json:"min,omitempty" yaml:"min,omitempty"`
@@ -36,33 +36,33 @@ type MetadataField struct {
 
 // MetadataFilter represents a filter for metadata queries
 type MetadataFilter struct {
-    // Backward-compatible flexible structure used by validators and handlers
-    // When Conditions is non-nil, it contains either typed MetadataCondition
-    // or map[string]interface{} entries with keys: key, operator, value/values.
-    Conditions []interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	// Backward-compatible flexible structure used by validators and handlers
+	// When Conditions is non-nil, it contains either typed MetadataCondition
+	// or map[string]interface{} entries with keys: key, operator, value/values.
+	Conditions []interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 
-    // Simple single-field filter (legacy)
-    Field    string      `json:"field,omitempty" yaml:"field,omitempty"`
-    Operator string      `json:"operator,omitempty" yaml:"operator,omitempty"` // "=", "!=", ">", "<", ">=", "<=", "in", "contains", "startswith", "endswith"
-    Value    interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	// Simple single-field filter (legacy)
+	Field    string      `json:"field,omitempty" yaml:"field,omitempty"`
+	Operator string      `json:"operator,omitempty" yaml:"operator,omitempty"` // "=", "!=", ">", "<", ">=", "<=", "in", "contains", "startswith", "endswith"
+	Value    interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // MetadataCondition is a typed representation of a filter condition
 type MetadataCondition struct {
-    Key      string   `json:"key" yaml:"key"`
-    Operator string   `json:"operator" yaml:"operator"`
-    Value    string   `json:"value,omitempty" yaml:"value,omitempty"`
-    Values   []string `json:"values,omitempty" yaml:"values,omitempty"`
+	Key      string   `json:"key" yaml:"key"`
+	Operator string   `json:"operator" yaml:"operator"`
+	Value    string   `json:"value,omitempty" yaml:"value,omitempty"`
+	Values   []string `json:"values,omitempty" yaml:"values,omitempty"`
 }
 
 // MetadataQuery represents a complex metadata query
 type MetadataQuery struct {
-	Filters    []MetadataFilter `json:"filters" yaml:"filters"`
-	Logic      string           `json:"logic" yaml:"logic"` // "AND", "OR"
-	Limit      int              `json:"limit,omitempty" yaml:"limit,omitempty"`
-	Offset     int              `json:"offset,omitempty" yaml:"offset,omitempty"`
-	SortBy     string           `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
-	SortOrder  string           `json:"sort_order,omitempty" yaml:"sort_order,omitempty"` // "asc", "desc"
+	Filters   []MetadataFilter `json:"filters" yaml:"filters"`
+	Logic     string           `json:"logic" yaml:"logic"` // "AND", "OR"
+	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Offset    int              `json:"offset,omitempty" yaml:"offset,omitempty"`
+	SortBy    string           `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
+	SortOrder string           `json:"sort_order,omitempty" yaml:"sort_order,omitempty"` // "asc", "desc"
 }
 
 // NewMetadata creates a new metadata instance
@@ -89,22 +89,22 @@ func (m *Metadata) Set(key string, value interface{}) error {
 	if m == nil {
 		return errors.New("metadata cannot be nil")
 	}
-	
+
 	if key == "" {
 		return errors.New("metadata key cannot be empty")
 	}
-	
+
 	// Validate against schema if present
 	if m.Schema != nil {
 		if err := m.validateField(key, value); err != nil {
 			return err
 		}
 	}
-	
+
 	m.Fields[key] = value
 	m.Timestamp = time.Now().Unix()
 	m.Version++
-	
+
 	return nil
 }
 
@@ -113,7 +113,7 @@ func (m *Metadata) Get(key string) (interface{}, bool) {
 	if m == nil || m.Fields == nil {
 		return nil, false
 	}
-	
+
 	value, exists := m.Fields[key]
 	return value, exists
 }
@@ -124,11 +124,11 @@ func (m *Metadata) GetString(key string) (string, bool) {
 	if !exists {
 		return "", false
 	}
-	
+
 	if str, ok := value.(string); ok {
 		return str, true
 	}
-	
+
 	return "", false
 }
 
@@ -138,7 +138,7 @@ func (m *Metadata) GetInt(key string) (int64, bool) {
 	if !exists {
 		return 0, false
 	}
-	
+
 	switch v := value.(type) {
 	case int:
 		return int64(v), true
@@ -159,7 +159,7 @@ func (m *Metadata) GetFloat(key string) (float64, bool) {
 	if !exists {
 		return 0, false
 	}
-	
+
 	switch v := value.(type) {
 	case float64:
 		return v, true
@@ -180,11 +180,11 @@ func (m *Metadata) GetBool(key string) (bool, bool) {
 	if !exists {
 		return false, false
 	}
-	
+
 	if b, ok := value.(bool); ok {
 		return b, true
 	}
-	
+
 	return false, false
 }
 
@@ -193,7 +193,7 @@ func (m *Metadata) Delete(key string) {
 	if m == nil || m.Fields == nil {
 		return
 	}
-	
+
 	delete(m.Fields, key)
 	m.Timestamp = time.Now().Unix()
 	m.Version++
@@ -204,7 +204,7 @@ func (m *Metadata) validateField(key string, value interface{}) error {
 	if m.Schema == nil {
 		return nil
 	}
-	
+
 	field, exists := m.Schema.Fields[key]
 	if !exists {
 		if m.Schema.Strict {
@@ -212,22 +212,22 @@ func (m *Metadata) validateField(key string, value interface{}) error {
 		}
 		return nil
 	}
-	
+
 	// Type validation
 	if err := m.validateType(field.Type, value); err != nil {
 		return fmt.Errorf("field '%s' type validation failed: %v", key, err)
 	}
-	
+
 	// Range validation
 	if err := m.validateRange(field, value); err != nil {
 		return fmt.Errorf("field '%s' range validation failed: %v", key, err)
 	}
-	
+
 	// Enum validation
 	if err := m.validateEnum(field, value); err != nil {
 		return fmt.Errorf("field '%s' enum validation failed: %v", key, err)
 	}
-	
+
 	return nil
 }
 
@@ -236,7 +236,7 @@ func (m *Metadata) validateType(expectedType string, value interface{}) error {
 	if value == nil {
 		return nil // Nil values are allowed (will use default if required)
 	}
-	
+
 	switch expectedType {
 	case "string":
 		if _, ok := value.(string); !ok {
@@ -269,7 +269,7 @@ func (m *Metadata) validateType(expectedType string, value interface{}) error {
 	default:
 		return fmt.Errorf("unknown field type: %s", expectedType)
 	}
-	
+
 	return nil
 }
 
@@ -278,37 +278,37 @@ func (m *Metadata) validateRange(field MetadataField, value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	
+
 	switch field.Type {
 	case "string":
 		str, ok := value.(string)
 		if !ok {
 			return nil
 		}
-		
+
 		if min, ok := field.Min.(int); ok && len(str) < min {
 			return fmt.Errorf("string length %d less than minimum %d", len(str), min)
 		}
-		
+
 		if max, ok := field.Max.(int); ok && len(str) > max {
 			return fmt.Errorf("string length %d greater than maximum %d", len(str), max)
 		}
-		
+
 	case "int", "float":
 		num, err := m.toFloat64(value)
 		if err != nil {
 			return nil
 		}
-		
+
 		if min, ok := field.Min.(float64); ok && num < min {
 			return fmt.Errorf("value %f less than minimum %f", num, min)
 		}
-		
+
 		if max, ok := field.Max.(float64); ok && num > max {
 			return fmt.Errorf("value %f greater than maximum %f", num, max)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -317,14 +317,14 @@ func (m *Metadata) validateEnum(field MetadataField, value interface{}) error {
 	if len(field.Enum) == 0 {
 		return nil
 	}
-	
+
 	valueStr := fmt.Sprintf("%v", value)
 	for _, enumVal := range field.Enum {
 		if enumVal == valueStr {
 			return nil
 		}
 	}
-	
+
 	return fmt.Errorf("value '%v' not in enum values: %v", value, field.Enum)
 }
 
@@ -386,12 +386,12 @@ func (m *Metadata) Matches(filter MetadataFilter) (bool, error) {
 	if m == nil {
 		return false, errors.New("metadata cannot be nil")
 	}
-	
+
 	value, exists := m.Get(filter.Field)
 	if !exists {
 		return false, nil
 	}
-	
+
 	return m.compareValues(value, filter.Operator, filter.Value)
 }
 
@@ -423,12 +423,12 @@ func (m *Metadata) compareNumeric(value interface{}, operator string, filterValu
 	if err != nil {
 		return false, err
 	}
-	
+
 	val2, err := m.toFloat64(filterValue)
 	if err != nil {
 		return false, err
 	}
-	
+
 	switch operator {
 	case ">":
 		return val1 > val2, nil
@@ -449,13 +449,13 @@ func (m *Metadata) compareIn(value interface{}, filterValue interface{}) (bool, 
 	if reflectValue.Kind() != reflect.Slice && reflectValue.Kind() != reflect.Array {
 		return false, fmt.Errorf("filter value for 'in' operator must be an array")
 	}
-	
+
 	for i := 0; i < reflectValue.Len(); i++ {
 		if reflect.DeepEqual(value, reflectValue.Index(i).Interface()) {
 			return true, nil
 		}
 	}
-	
+
 	return false, nil
 }
 
@@ -465,12 +465,12 @@ func (m *Metadata) compareContains(value interface{}, filterValue interface{}) (
 	if !ok {
 		return false, fmt.Errorf("value for 'contains' operator must be a string")
 	}
-	
+
 	filterStr, ok := filterValue.(string)
 	if !ok {
 		return false, fmt.Errorf("filter value for 'contains' operator must be a string")
 	}
-	
+
 	return strings.Contains(valStr, filterStr), nil
 }
 
@@ -480,12 +480,12 @@ func (m *Metadata) compareStartsWith(value interface{}, filterValue interface{})
 	if !ok {
 		return false, fmt.Errorf("value for 'startswith' operator must be a string")
 	}
-	
+
 	filterStr, ok := filterValue.(string)
 	if !ok {
 		return false, fmt.Errorf("filter value for 'startswith' operator must be a string")
 	}
-	
+
 	return strings.HasPrefix(valStr, filterStr), nil
 }
 
@@ -495,12 +495,12 @@ func (m *Metadata) compareEndsWith(value interface{}, filterValue interface{}) (
 	if !ok {
 		return false, fmt.Errorf("value for 'endswith' operator must be a string")
 	}
-	
+
 	filterStr, ok := filterValue.(string)
 	if !ok {
 		return false, fmt.Errorf("filter value for 'endswith' operator must be a string")
 	}
-	
+
 	return strings.HasSuffix(valStr, filterStr), nil
 }
 
@@ -509,7 +509,7 @@ func (m *Metadata) Serialize() ([]byte, error) {
 	if m == nil {
 		return nil, errors.New("cannot serialize nil metadata")
 	}
-	
+
 	return json.Marshal(m)
 }
 
@@ -518,12 +518,12 @@ func DeserializeMetadata(data []byte) (*Metadata, error) {
 	if len(data) == 0 {
 		return NewMetadata(), nil
 	}
-	
+
 	var metadata Metadata
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("failed to deserialize metadata: %v", err)
 	}
-	
+
 	return &metadata, nil
 }
 
@@ -532,12 +532,12 @@ func (m *Metadata) Clone() (*Metadata, error) {
 	if m == nil {
 		return nil, errors.New("cannot clone nil metadata")
 	}
-	
+
 	data, err := m.Serialize()
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return DeserializeMetadata(data)
 }
 
@@ -546,12 +546,12 @@ func (m *Metadata) Merge(other *Metadata) error {
 	if m == nil || other == nil {
 		return errors.New("cannot merge nil metadata")
 	}
-	
+
 	for key, value := range other.Fields {
 		if err := m.Set(key, value); err != nil {
 			return err
 		}
 	}
-	
+
 	return nil
 }

--- a/internal/types/query.go
+++ b/internal/types/query.go
@@ -6,78 +6,78 @@ import (
 
 // Config represents the system configuration
 type Config struct {
-	Service      ServiceConfig      `json:"service" yaml:"service"`
-	Storage      StorageConfig      `json:"storage" yaml:"storage"`
-	Cluster      ClusterConfig      `json:"cluster" yaml:"cluster"`
-	Search       SearchConfig       `json:"search" yaml:"search"`
-	Network      NetworkConfig      `json:"network" yaml:"network"`
-	Metrics      MetricsConfig      `json:"metrics" yaml:"metrics"`
-	Logging      LoggingConfig      `json:"logging" yaml:"logging"`
-	Health       HealthConfig       `json:"health" yaml:"health"`
+	Service ServiceConfig `json:"service" yaml:"service"`
+	Storage StorageConfig `json:"storage" yaml:"storage"`
+	Cluster ClusterConfig `json:"cluster" yaml:"cluster"`
+	Search  SearchConfig  `json:"search" yaml:"search"`
+	Network NetworkConfig `json:"network" yaml:"network"`
+	Metrics MetricsConfig `json:"metrics" yaml:"metrics"`
+	Logging LoggingConfig `json:"logging" yaml:"logging"`
+	Health  HealthConfig  `json:"health" yaml:"health"`
 }
 
 // ServiceConfig represents service-specific configuration
 type ServiceConfig struct {
-	Name        string        `json:"name" yaml:"name"`
-	Version     string        `json:"version" yaml:"version"`
-	Environment string        `json:"environment" yaml:"environment"`
-	Host        string        `json:"host" yaml:"host"`
-	Port        int           `json:"port" yaml:"port"`
+	Name        string         `json:"name" yaml:"name"`
+	Version     string         `json:"version" yaml:"version"`
+	Environment string         `json:"environment" yaml:"environment"`
+	Host        string         `json:"host" yaml:"host"`
+	Port        int            `json:"port" yaml:"port"`
 	Shutdown    ShutdownConfig `json:"shutdown" yaml:"shutdown"`
 }
 
 // StorageConfig represents storage-specific configuration
 type StorageConfig struct {
-	DataDir           string            `json:"data_dir" yaml:"data_dir"`
-	MaxSegmentSize    int64             `json:"max_segment_size" yaml:"max_segment_size"`
-	Compression       CompressionConfig `json:"compression" yaml:"compression"`
-	Buffer            BufferConfig      `json:"buffer" yaml:"buffer"`
-	Hashing           HashingConfig     `json:"hashing" yaml:"hashing"`
+	DataDir        string            `json:"data_dir" yaml:"data_dir"`
+	MaxSegmentSize int64             `json:"max_segment_size" yaml:"max_segment_size"`
+	Compression    CompressionConfig `json:"compression" yaml:"compression"`
+	Buffer         BufferConfig      `json:"buffer" yaml:"buffer"`
+	Hashing        HashingConfig     `json:"hashing" yaml:"hashing"`
 }
 
 // SearchConfig represents search-specific configuration
 type SearchConfig struct {
-	Engine          string         `json:"engine" yaml:"engine"`
-	MaxResults      int            `json:"max_results" yaml:"max_results"`
-	DefaultK        int            `json:"default_k" yaml:"default_k"`
-	DistanceType    string         `json:"distance_type" yaml:"distance_type"`
-	Parallel        ParallelConfig `json:"parallel" yaml:"parallel"`
+	Engine       string         `json:"engine" yaml:"engine"`
+	MaxResults   int            `json:"max_results" yaml:"max_results"`
+	DefaultK     int            `json:"default_k" yaml:"default_k"`
+	DistanceType string         `json:"distance_type" yaml:"distance_type"`
+	Parallel     ParallelConfig `json:"parallel" yaml:"parallel"`
 }
 
 // NetworkConfig represents network-specific configuration
 type NetworkConfig struct {
-	GRPC     GRPCConfig     `json:"grpc" yaml:"grpc"`
-	HTTP     HTTPConfig     `json:"http" yaml:"http"`
+	GRPC      GRPCConfig      `json:"grpc" yaml:"grpc"`
+	HTTP      HTTPConfig      `json:"http" yaml:"http"`
 	WebSocket WebSocketConfig `json:"websocket" yaml:"websocket"`
 }
 
 // MetricsConfig represents metrics-specific configuration
 type MetricsConfig struct {
-	Enabled    bool     `json:"enabled" yaml:"enabled"`
-	Namespace  string   `json:"namespace" yaml:"namespace"`
-	Subsystem  string   `json:"subsystem" yaml:"subsystem"`
-	Address    string   `json:"address" yaml:"address"`
-	Path       string   `json:"path" yaml:"path"`
-	Buckets    []float64 `json:"buckets" yaml:"buckets"`
+	Enabled   bool      `json:"enabled" yaml:"enabled"`
+	Namespace string    `json:"namespace" yaml:"namespace"`
+	Subsystem string    `json:"subsystem" yaml:"subsystem"`
+	Address   string    `json:"address" yaml:"address"`
+	Path      string    `json:"path" yaml:"path"`
+	Buckets   []float64 `json:"buckets" yaml:"buckets"`
 }
 
 // LoggingConfig represents logging-specific configuration
 type LoggingConfig struct {
-	Enabled   bool   `json:"enabled" yaml:"enabled"`
-	Level     string `json:"level" yaml:"level"`
-	Format    string `json:"format" yaml:"format"`
-	Output    string `json:"output" yaml:"output"`
-	MaxSize   int    `json:"max_size" yaml:"max_size"`
-	MaxAge    int    `json:"max_age" yaml:"max_age"`
-	MaxBackups int   `json:"max_backups" yaml:"max_backups"`
-	Compress  bool   `json:"compress" yaml:"compress"`
+	Enabled    bool   `json:"enabled" yaml:"enabled"`
+	Level      string `json:"level" yaml:"level"`
+	Format     string `json:"format" yaml:"format"`
+	Output     string `json:"output" yaml:"output"`
+	MaxSize    int    `json:"max_size" yaml:"max_size"`
+	MaxAge     int    `json:"max_age" yaml:"max_age"`
+	MaxBackups int    `json:"max_backups" yaml:"max_backups"`
+	Compress   bool   `json:"compress" yaml:"compress"`
 }
 
 // HealthConfig represents health-specific configuration
 type HealthConfig struct {
-	Enabled     bool          `json:"enabled" yaml:"enabled"`
+	Enabled       bool          `json:"enabled" yaml:"enabled"`
 	CheckInterval time.Duration `json:"check_interval" yaml:"check_interval"`
-	Timeout     time.Duration `json:"timeout" yaml:"timeout"`
+	Timeout       time.Duration `json:"timeout" yaml:"timeout"`
 }
 
 // ShutdownConfig represents shutdown-specific configuration
@@ -105,11 +105,11 @@ type BufferConfig struct {
 
 // HashingConfig represents hashing-specific configuration
 type HashingConfig struct {
-	Algorithm     string `json:"algorithm" yaml:"algorithm"`
-	Strategy      string `json:"strategy" yaml:"strategy"`
-	ClusterCount  uint32 `json:"cluster_count" yaml:"cluster_count"`
-	Seed          uint64 `json:"seed" yaml:"seed"`
-	EnableCache   bool   `json:"enable_cache" yaml:"enable_cache"`
+	Algorithm    string `json:"algorithm" yaml:"algorithm"`
+	Strategy     string `json:"strategy" yaml:"strategy"`
+	ClusterCount uint32 `json:"cluster_count" yaml:"cluster_count"`
+	Seed         uint64 `json:"seed" yaml:"seed"`
+	EnableCache  bool   `json:"enable_cache" yaml:"enable_cache"`
 }
 
 // ParallelConfig represents parallel search configuration
@@ -121,29 +121,29 @@ type ParallelConfig struct {
 
 // GRPCConfig represents gRPC-specific configuration
 type GRPCConfig struct {
-	Enabled    bool   `json:"enabled" yaml:"enabled"`
-	Host       string `json:"host" yaml:"host"`
-	Port       int    `json:"port" yaml:"port"`
-	MaxConn    int    `json:"max_conn" yaml:"max_conn"`
-	Timeout    int    `json:"timeout" yaml:"timeout"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Host    string `json:"host" yaml:"host"`
+	Port    int    `json:"port" yaml:"port"`
+	MaxConn int    `json:"max_conn" yaml:"max_conn"`
+	Timeout int    `json:"timeout" yaml:"timeout"`
 }
 
 // HTTPConfig represents HTTP-specific configuration
 type HTTPConfig struct {
-	Enabled    bool   `json:"enabled" yaml:"enabled"`
-	Host       string `json:"host" yaml:"host"`
-	Port       int    `json:"port" yaml:"port"`
-	MaxConn    int    `json:"max_conn" yaml:"max_conn"`
-	Timeout    int    `json:"timeout" yaml:"timeout"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Host    string `json:"host" yaml:"host"`
+	Port    int    `json:"port" yaml:"port"`
+	MaxConn int    `json:"max_conn" yaml:"max_conn"`
+	Timeout int    `json:"timeout" yaml:"timeout"`
 }
 
 // WebSocketConfig represents WebSocket-specific configuration
 type WebSocketConfig struct {
-	Enabled    bool   `json:"enabled" yaml:"enabled"`
-	Host       string `json:"host" yaml:"host"`
-	Port       int    `json:"port" yaml:"port"`
-	MaxConn    int    `json:"max_conn" yaml:"max_conn"`
-	Timeout    int    `json:"timeout" yaml:"timeout"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Host    string `json:"host" yaml:"host"`
+	Port    int    `json:"port" yaml:"port"`
+	MaxConn int    `json:"max_conn" yaml:"max_conn"`
+	Timeout int    `json:"timeout" yaml:"timeout"`
 }
 
 // QueryPlan represents a query execution plan
@@ -160,41 +160,41 @@ type QueryPlan struct {
 
 // QueryNode represents a node in the query plan
 type QueryNode struct {
-	ID         string            `json:"id" yaml:"id"`
-	Address    string            `json:"address" yaml:"address"`
-	Port       int               `json:"port" yaml:"port"`
-	Role       string            `json:"role" yaml:"role"`
-	Clusters   []uint32          `json:"clusters" yaml:"clusters"`
-	Status     string            `json:"status" yaml:"status"`
-	StartTime  time.Time         `json:"start_time" yaml:"start_time"`
-	EndTime    *time.Time        `json:"end_time,omitempty" yaml:"end_time,omitempty"`
-	Error      string            `json:"error,omitempty" yaml:"error,omitempty"`
-	Results    []*SearchResult   `json:"results,omitempty" yaml:"results,omitempty"`
+	ID        string          `json:"id" yaml:"id"`
+	Address   string          `json:"address" yaml:"address"`
+	Port      int             `json:"port" yaml:"port"`
+	Role      string          `json:"role" yaml:"role"`
+	Clusters  []uint32        `json:"clusters" yaml:"clusters"`
+	Status    string          `json:"status" yaml:"status"`
+	StartTime time.Time       `json:"start_time" yaml:"start_time"`
+	EndTime   *time.Time      `json:"end_time,omitempty" yaml:"end_time,omitempty"`
+	Error     string          `json:"error,omitempty" yaml:"error,omitempty"`
+	Results   []*SearchResult `json:"results,omitempty" yaml:"results,omitempty"`
 }
 
 // QueryStats represents query execution statistics
 type QueryStats struct {
-	QueryID        string        `json:"query_id" yaml:"query_id"`
-	TotalNodes     int           `json:"total_nodes" yaml:"total_nodes"`
-	SuccessfulNodes int          `json:"successful_nodes" yaml:"successful_nodes"`
-	FailedNodes    int           `json:"failed_nodes" yaml:"failed_nodes"`
-	TotalResults   int           `json:"total_results" yaml:"total_results"`
-	ExecutionTime  time.Duration `json:"execution_time" yaml:"execution_time"`
-	NetworkTime    time.Duration `json:"network_time" yaml:"network_time"`
-	SearchTime     time.Duration `json:"search_time" yaml:"search_time"`
-	MergeTime      time.Duration `json:"merge_time" yaml:"merge_time"`
-	StartTime      time.Time     `json:"start_time" yaml:"start_time"`
-	EndTime        time.Time     `json:"end_time" yaml:"end_time"`
-	Errors         []string      `json:"errors,omitempty" yaml:"errors,omitempty"`
+	QueryID         string        `json:"query_id" yaml:"query_id"`
+	TotalNodes      int           `json:"total_nodes" yaml:"total_nodes"`
+	SuccessfulNodes int           `json:"successful_nodes" yaml:"successful_nodes"`
+	FailedNodes     int           `json:"failed_nodes" yaml:"failed_nodes"`
+	TotalResults    int           `json:"total_results" yaml:"total_results"`
+	ExecutionTime   time.Duration `json:"execution_time" yaml:"execution_time"`
+	NetworkTime     time.Duration `json:"network_time" yaml:"network_time"`
+	SearchTime      time.Duration `json:"search_time" yaml:"search_time"`
+	MergeTime       time.Duration `json:"merge_time" yaml:"merge_time"`
+	StartTime       time.Time     `json:"start_time" yaml:"start_time"`
+	EndTime         time.Time     `json:"end_time" yaml:"end_time"`
+	Errors          []string      `json:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 // AggregatedResult represents aggregated search results from multiple nodes
 type AggregatedResult struct {
-	QueryID    string          `json:"query_id" yaml:"query_id"`
-	Results    []*SearchResult `json:"results" yaml:"results"`
-	Total      int             `json:"total" yaml:"total"`
-	K          int             `json:"k" yaml:"k"`
-	Stats      *QueryStats     `json:"stats,omitempty" yaml:"stats,omitempty"`
-	Success    bool            `json:"success" yaml:"success"`
-	Error      string          `json:"error,omitempty" yaml:"error,omitempty"`
+	QueryID string          `json:"query_id" yaml:"query_id"`
+	Results []*SearchResult `json:"results" yaml:"results"`
+	Total   int             `json:"total" yaml:"total"`
+	K       int             `json:"k" yaml:"k"`
+	Stats   *QueryStats     `json:"stats,omitempty" yaml:"stats,omitempty"`
+	Success bool            `json:"success" yaml:"success"`
+	Error   string          `json:"error,omitempty" yaml:"error,omitempty"`
 }

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -129,5 +129,5 @@ type SegmentInfo struct {
 
 // ClusterIDString returns a string representation of the cluster ID
 func (si *SegmentInfo) ClusterIDString() string {
-       return fmt.Sprintf("%d", si.ClusterID)
+	return fmt.Sprintf("%d", si.ClusterID)
 }

--- a/internal/types/system.go
+++ b/internal/types/system.go
@@ -6,83 +6,83 @@ import (
 
 // SystemHealth represents the overall health of the system
 type SystemHealth struct {
-	Status      string            `json:"status" yaml:"status"`      // "healthy", "unhealthy", "degraded"
-	Message     string            `json:"message,omitempty" yaml:"message,omitempty"`
-	Timestamp   time.Time         `json:"timestamp" yaml:"timestamp"`
-	Version     string            `json:"version" yaml:"version"`
-	Uptime      time.Duration     `json:"uptime" yaml:"uptime"`
-	Services    []ServiceHealth   `json:"services" yaml:"services"`
-	Components  []ComponentHealth `json:"components" yaml:"components"`
-	Metrics     map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	Status     string                 `json:"status" yaml:"status"` // "healthy", "unhealthy", "degraded"
+	Message    string                 `json:"message,omitempty" yaml:"message,omitempty"`
+	Timestamp  time.Time              `json:"timestamp" yaml:"timestamp"`
+	Version    string                 `json:"version" yaml:"version"`
+	Uptime     time.Duration          `json:"uptime" yaml:"uptime"`
+	Services   []ServiceHealth        `json:"services" yaml:"services"`
+	Components []ComponentHealth      `json:"components" yaml:"components"`
+	Metrics    map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
 }
 
 // ServiceHealth represents the health of a service
 type ServiceHealth struct {
-	Name      string            `json:"name" yaml:"name"`
-	Status    string            `json:"status" yaml:"status"`    // "healthy", "unhealthy", "degraded"
-	Message   string            `json:"message,omitempty" yaml:"message,omitempty"`
-	Host      string            `json:"host" yaml:"host"`
-	Port      int               `json:"port" yaml:"port"`
-	Version   string            `json:"version" yaml:"version"`
-	Uptime    time.Duration     `json:"uptime" yaml:"uptime"`
-	Checks    []HealthCheck     `json:"checks,omitempty" yaml:"checks,omitempty"`
-	Metrics   map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	Name    string                 `json:"name" yaml:"name"`
+	Status  string                 `json:"status" yaml:"status"` // "healthy", "unhealthy", "degraded"
+	Message string                 `json:"message,omitempty" yaml:"message,omitempty"`
+	Host    string                 `json:"host" yaml:"host"`
+	Port    int                    `json:"port" yaml:"port"`
+	Version string                 `json:"version" yaml:"version"`
+	Uptime  time.Duration          `json:"uptime" yaml:"uptime"`
+	Checks  []HealthCheck          `json:"checks,omitempty" yaml:"checks,omitempty"`
+	Metrics map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
 }
 
 // ComponentHealth represents the health of a component
 type ComponentHealth struct {
-	Name      string            `json:"name" yaml:"name"`
-	Type      string            `json:"type" yaml:"type"`        // "storage", "search", "network", etc.
-	Status    string            `json:"status" yaml:"status"`    // "healthy", "unhealthy", "degraded"
-	Message   string            `json:"message,omitempty" yaml:"message,omitempty"`
-	Metrics   map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
-	Checks    []HealthCheck     `json:"checks,omitempty" yaml:"checks,omitempty"`
+	Name    string                 `json:"name" yaml:"name"`
+	Type    string                 `json:"type" yaml:"type"`     // "storage", "search", "network", etc.
+	Status  string                 `json:"status" yaml:"status"` // "healthy", "unhealthy", "degraded"
+	Message string                 `json:"message,omitempty" yaml:"message,omitempty"`
+	Metrics map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	Checks  []HealthCheck          `json:"checks,omitempty" yaml:"checks,omitempty"`
 }
 
 // MetricPoint represents a single metric data point
 type MetricPoint struct {
-	Name      string                 `json:"name" yaml:"name"`
-	Value     float64                `json:"value" yaml:"value"`
-	Timestamp time.Time              `json:"timestamp" yaml:"timestamp"`
-	Tags      map[string]string      `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Type      string                 `json:"type" yaml:"type"`        // "gauge", "counter", "histogram", "summary"
-	Help      string                 `json:"help,omitempty" yaml:"help,omitempty"`
+	Name      string            `json:"name" yaml:"name"`
+	Value     float64           `json:"value" yaml:"value"`
+	Timestamp time.Time         `json:"timestamp" yaml:"timestamp"`
+	Tags      map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Type      string            `json:"type" yaml:"type"` // "gauge", "counter", "histogram", "summary"
+	Help      string            `json:"help,omitempty" yaml:"help,omitempty"`
 }
 
 // ConfigVersion represents configuration version information
 type ConfigVersion struct {
-	Version   string            `json:"version" yaml:"version"`
-	Hash      string            `json:"hash" yaml:"hash"`
-	Timestamp time.Time         `json:"timestamp" yaml:"timestamp"`
-	Source    string            `json:"source" yaml:"source"`        // "file", "env", "default"
-	ChangedBy string            `json:"changed_by,omitempty" yaml:"changed_by,omitempty"`
-	Changes   []ConfigChange    `json:"changes,omitempty" yaml:"changes,omitempty"`
+	Version   string         `json:"version" yaml:"version"`
+	Hash      string         `json:"hash" yaml:"hash"`
+	Timestamp time.Time      `json:"timestamp" yaml:"timestamp"`
+	Source    string         `json:"source" yaml:"source"` // "file", "env", "default"
+	ChangedBy string         `json:"changed_by,omitempty" yaml:"changed_by,omitempty"`
+	Changes   []ConfigChange `json:"changes,omitempty" yaml:"changes,omitempty"`
 }
 
 // ConfigChange represents a configuration change
 type ConfigChange struct {
 	Path      string      `json:"path" yaml:"path"`
-	OldValue interface{} `json:"old_value,omitempty" yaml:"old_value,omitempty"`
-	NewValue interface{} `json:"new_value,omitempty" yaml:"new_value,omitempty"`
+	OldValue  interface{} `json:"old_value,omitempty" yaml:"old_value,omitempty"`
+	NewValue  interface{} `json:"new_value,omitempty" yaml:"new_value,omitempty"`
 	Timestamp time.Time   `json:"timestamp" yaml:"timestamp"`
 	Reason    string      `json:"reason,omitempty" yaml:"reason,omitempty"`
 }
 
 // ServiceStatus represents the status of a service
 type ServiceStatus struct {
-	ID          string            `json:"id" yaml:"id"`
-	Name        string            `json:"name" yaml:"name"`
-	Type        string            `json:"type" yaml:"type"`        // "vexstorage", "vexinsert", "vexsearch"
-	Status      string            `json:"status" yaml:"status"`    // "running", "stopped", "error", "starting", "stopping"
-	Host        string            `json:"host" yaml:"host"`
-	Port        int               `json:"port" yaml:"port"`
-	Version     string            `json:"version" yaml:"version"`
-	Uptime      time.Duration     `json:"uptime" yaml:"uptime"`
-	Health      string            `json:"health" yaml:"health"`    // "healthy", "unhealthy", "degraded"
-	Message     string            `json:"message,omitempty" yaml:"message,omitempty"`
-	Metrics     map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
-	LastCheck   time.Time         `json:"last_check" yaml:"last_check"`
-	StartedAt   time.Time         `json:"started_at" yaml:"started_at"`
+	ID        string                 `json:"id" yaml:"id"`
+	Name      string                 `json:"name" yaml:"name"`
+	Type      string                 `json:"type" yaml:"type"`     // "vxstorage", "vxinsert", "vxsearch"
+	Status    string                 `json:"status" yaml:"status"` // "running", "stopped", "error", "starting", "stopping"
+	Host      string                 `json:"host" yaml:"host"`
+	Port      int                    `json:"port" yaml:"port"`
+	Version   string                 `json:"version" yaml:"version"`
+	Uptime    time.Duration          `json:"uptime" yaml:"uptime"`
+	Health    string                 `json:"health" yaml:"health"` // "healthy", "unhealthy", "degraded"
+	Message   string                 `json:"message,omitempty" yaml:"message,omitempty"`
+	Metrics   map[string]interface{} `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	LastCheck time.Time              `json:"last_check" yaml:"last_check"`
+	StartedAt time.Time              `json:"started_at" yaml:"started_at"`
 }
 
 // SystemMetrics represents system-wide metrics
@@ -97,18 +97,18 @@ type SystemMetrics struct {
 
 // ServiceMetrics represents metrics for a single service
 type ServiceMetrics struct {
-	Name        string                 `json:"name" yaml:"name"`
-	Type        string                 `json:"type" yaml:"type"`
-	Host        string                 `json:"host" yaml:"host"`
-	Port        int                    `json:"port" yaml:"port"`
-	Status      string                 `json:"status" yaml:"status"`
-	Health      string                 `json:"health" yaml:"health"`
-	Uptime      time.Duration          `json:"uptime" yaml:"uptime"`
-	Requests    int64                  `json:"requests" yaml:"requests"`
-	Errors      int64                  `json:"errors" yaml:"errors"`
-	Latency     float64                `json:"latency" yaml:"latency"`     // in milliseconds
-	Throughput  float64                `json:"throughput" yaml:"throughput"` // requests per second
-	Custom      map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
+	Name       string                 `json:"name" yaml:"name"`
+	Type       string                 `json:"type" yaml:"type"`
+	Host       string                 `json:"host" yaml:"host"`
+	Port       int                    `json:"port" yaml:"port"`
+	Status     string                 `json:"status" yaml:"status"`
+	Health     string                 `json:"health" yaml:"health"`
+	Uptime     time.Duration          `json:"uptime" yaml:"uptime"`
+	Requests   int64                  `json:"requests" yaml:"requests"`
+	Errors     int64                  `json:"errors" yaml:"errors"`
+	Latency    float64                `json:"latency" yaml:"latency"`       // in milliseconds
+	Throughput float64                `json:"throughput" yaml:"throughput"` // requests per second
+	Custom     map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 // ResourceMetrics represents system resource metrics
@@ -121,49 +121,49 @@ type ResourceMetrics struct {
 
 // CPUInfo represents CPU information
 type CPUInfo struct {
-	Usage     float64 `json:"usage" yaml:"usage"`        // percentage
+	Usage     float64 `json:"usage" yaml:"usage"` // percentage
 	Cores     int     `json:"cores" yaml:"cores"`
 	Frequency float64 `json:"frequency" yaml:"frequency"` // in MHz
-	Load1     float64 `json:"load1" yaml:"load1"`        // 1-minute load average
-	Load5     float64 `json:"load5" yaml:"load5"`        // 5-minute load average
-	Load15    float64 `json:"load15" yaml:"load15"`      // 15-minute load average
+	Load1     float64 `json:"load1" yaml:"load1"`         // 1-minute load average
+	Load5     float64 `json:"load5" yaml:"load5"`         // 5-minute load average
+	Load15    float64 `json:"load15" yaml:"load15"`       // 15-minute load average
 }
 
 // MemoryInfo represents memory information
 type MemoryInfo struct {
-	Total     uint64  `json:"total" yaml:"total"`        // in bytes
-	Used      uint64  `json:"used" yaml:"used"`          // in bytes
-	Free      uint64  `json:"free" yaml:"free"`          // in bytes
+	Total     uint64  `json:"total" yaml:"total"`         // in bytes
+	Used      uint64  `json:"used" yaml:"used"`           // in bytes
+	Free      uint64  `json:"free" yaml:"free"`           // in bytes
 	Available uint64  `json:"available" yaml:"available"` // in bytes
-	Usage     float64 `json:"usage" yaml:"usage"`        // percentage
+	Usage     float64 `json:"usage" yaml:"usage"`         // percentage
 }
 
 // DiskInfo represents disk information
 type DiskInfo struct {
-	Total     uint64  `json:"total" yaml:"total"`        // in bytes
-	Used      uint64  `json:"used" yaml:"used"`          // in bytes
-	Free      uint64  `json:"free" yaml:"free"`          // in bytes
-	Usage     float64 `json:"usage" yaml:"usage"`        // percentage
-	Reads     uint64  `json:"reads" yaml:"reads"`        // number of reads
-	Writes    uint64  `json:"writes" yaml:"writes"`      // number of writes
+	Total  uint64  `json:"total" yaml:"total"`   // in bytes
+	Used   uint64  `json:"used" yaml:"used"`     // in bytes
+	Free   uint64  `json:"free" yaml:"free"`     // in bytes
+	Usage  float64 `json:"usage" yaml:"usage"`   // percentage
+	Reads  uint64  `json:"reads" yaml:"reads"`   // number of reads
+	Writes uint64  `json:"writes" yaml:"writes"` // number of writes
 }
 
 // NetworkInfo represents network information
 type NetworkInfo struct {
-	BytesSent     uint64  `json:"bytes_sent" yaml:"bytes_sent"`
-	BytesReceived uint64  `json:"bytes_received" yaml:"bytes_received"`
-	PacketsSent   uint64  `json:"packets_sent" yaml:"packets_sent"`
-	PacketsRecv   uint64  `json:"packets_recv" yaml:"packets_recv"`
-	ErrorsIn      uint64  `json:"errors_in" yaml:"errors_in"`
-	ErrorsOut     uint64  `json:"errors_out" yaml:"errors_out"`
+	BytesSent     uint64 `json:"bytes_sent" yaml:"bytes_sent"`
+	BytesReceived uint64 `json:"bytes_received" yaml:"bytes_received"`
+	PacketsSent   uint64 `json:"packets_sent" yaml:"packets_sent"`
+	PacketsRecv   uint64 `json:"packets_recv" yaml:"packets_recv"`
+	ErrorsIn      uint64 `json:"errors_in" yaml:"errors_in"`
+	ErrorsOut     uint64 `json:"errors_out" yaml:"errors_out"`
 }
 
 // PerformanceMetrics represents performance metrics
 type PerformanceMetrics struct {
-	QueryLatency    float64 `json:"query_latency" yaml:"query_latency"`        // in milliseconds
-	IngestLatency   float64 `json:"ingest_latency" yaml:"ingest_latency"`       // in milliseconds
-	Throughput      float64 `json:"throughput" yaml:"throughput"`               // operations per second
-	ErrorRate       float64 `json:"error_rate" yaml:"error_rate"`               // percentage
-	Availability    float64 `json:"availability" yaml:"availability"`           // percentage
-	Saturation      float64 `json:"saturation" yaml:"saturation"`               // percentage
+	QueryLatency  float64 `json:"query_latency" yaml:"query_latency"`   // in milliseconds
+	IngestLatency float64 `json:"ingest_latency" yaml:"ingest_latency"` // in milliseconds
+	Throughput    float64 `json:"throughput" yaml:"throughput"`         // operations per second
+	ErrorRate     float64 `json:"error_rate" yaml:"error_rate"`         // percentage
+	Availability  float64 `json:"availability" yaml:"availability"`     // percentage
+	Saturation    float64 `json:"saturation" yaml:"saturation"`         // percentage
 }

--- a/internal/types/vector.go
+++ b/internal/types/vector.go
@@ -12,17 +12,17 @@ type Vector struct {
 	ID        string                 `json:"id" yaml:"id"`
 	Data      []float32              `json:"data" yaml:"data"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	ClusterID uint32                `json:"cluster_id" yaml:"cluster_id"`
-	Timestamp int64                 `json:"timestamp" yaml:"timestamp"`
+	ClusterID uint32                 `json:"cluster_id" yaml:"cluster_id"`
+	Timestamp int64                  `json:"timestamp" yaml:"timestamp"`
 }
 
 // VectorConfig defines configuration for vector operations
 type VectorConfig struct {
-	Dimensions    int     `json:"dimensions" yaml:"dimensions"`
-	MaxDimensions int     `json:"max_dimensions" yaml:"max_dimensions"`
-	MinDimensions int     `json:"min_dimensions" yaml:"min_dimensions"`
-	Normalize     bool    `json:"normalize" yaml:"normalize"`
-	DistanceType  string  `json:"distance_type" yaml:"distance_type"` // "cosine", "euclidean", "dotproduct"
+	Dimensions    int    `json:"dimensions" yaml:"dimensions"`
+	MaxDimensions int    `json:"max_dimensions" yaml:"max_dimensions"`
+	MinDimensions int    `json:"min_dimensions" yaml:"min_dimensions"`
+	Normalize     bool   `json:"normalize" yaml:"normalize"`
+	DistanceType  string `json:"distance_type" yaml:"distance_type"` // "cosine", "euclidean", "dotproduct"
 }
 
 // NewVector creates a new vector with validation
@@ -30,63 +30,63 @@ func NewVector(id string, data []float32, metadata map[string]interface{}) (*Vec
 	if id == "" {
 		return nil, errors.New("vector ID cannot be empty")
 	}
-	
+
 	if len(data) == 0 {
 		return nil, errors.New("vector data cannot be empty")
 	}
-	
+
 	if len(data) > 10000 { // Reasonable upper limit
 		return nil, fmt.Errorf("vector dimensions %d exceeds maximum allowed", len(data))
 	}
-	
+
 	// Validate vector data
 	for i, val := range data {
 		if math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
 			return nil, fmt.Errorf("vector data contains invalid value at index %d: %f", i, val)
 		}
 	}
-	
+
 	vector := &Vector{
 		ID:        id,
 		Data:      make([]float32, len(data)),
 		Metadata:  metadata,
 		Timestamp: 0, // Will be set by the system
 	}
-	
+
 	// Copy data to avoid external modification
 	copy(vector.Data, data)
-	
+
 	return vector, nil
 }
 
 // Validate validates the vector data with optional config
 func (v *Vector) ValidateWithConfig(config *VectorConfig) error {
-    if v == nil {
-        return errors.New("vector cannot be nil")
-    }
-	
+	if v == nil {
+		return errors.New("vector cannot be nil")
+	}
+
 	if len(v.Data) == 0 {
 		return errors.New("vector data cannot be empty")
 	}
-	
+
 	if config != nil {
 		if len(v.Data) < config.MinDimensions {
 			return fmt.Errorf("vector dimensions %d below minimum required %d", len(v.Data), config.MinDimensions)
 		}
-		
+
 		if len(v.Data) > config.MaxDimensions {
 			return fmt.Errorf("vector dimensions %d exceeds maximum allowed %d", len(v.Data), config.MaxDimensions)
 		}
 	}
-	
+
 	// Validate vector data
 	for i, val := range v.Data {
 		if math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
 			return fmt.Errorf("vector data contains invalid value at index %d: %f", i, val)
 		}
 	}
-	
-    return nil
+
+	return nil
 }
 
 // Validate validates the vector with default rules (no extra constraints)
@@ -97,21 +97,21 @@ func (v *Vector) Normalize() error {
 	if len(v.Data) == 0 {
 		return errors.New("cannot normalize empty vector")
 	}
-	
+
 	var norm float64
 	for _, val := range v.Data {
 		norm += float64(val) * float64(val)
 	}
-	
+
 	norm = math.Sqrt(norm)
 	if norm == 0 {
 		return errors.New("cannot normalize zero vector")
 	}
-	
+
 	for i := range v.Data {
 		v.Data[i] = float32(float64(v.Data[i]) / norm)
 	}
-	
+
 	return nil
 }
 
@@ -120,7 +120,7 @@ func (v *Vector) Distance(other *Vector, distanceType string) (float64, error) {
 	if len(v.Data) != len(other.Data) {
 		return 0, fmt.Errorf("vector dimensions mismatch: %d vs %d", len(v.Data), len(other.Data))
 	}
-	
+
 	switch distanceType {
 	case "cosine":
 		return v.cosineDistance(other), nil
@@ -138,11 +138,11 @@ func (v *Vector) cosineDistance(other *Vector) float64 {
 	dotProduct := v.dotProduct(other)
 	norm1 := v.magnitude()
 	norm2 := other.magnitude()
-	
+
 	if norm1 == 0 || norm2 == 0 {
 		return 1.0 // Maximum distance for zero vectors
 	}
-	
+
 	return 1.0 - (dotProduct / (norm1 * norm2))
 }
 
@@ -176,7 +176,7 @@ func (v *Vector) magnitude() float64 {
 
 // Size returns the size of vector in bytes for serialization
 func (v *Vector) Size() int {
-	// ID (4 bytes len + len(ID)) + Data (4 bytes len + len(Data)*4) + 
+	// ID (4 bytes len + len(ID)) + Data (4 bytes len + len(Data)*4) +
 	// Metadata (variable) + ClusterID (4) + Timestamp (8)
 	return 4 + len(v.ID) + 4 + len(v.Data)*4 + v.metadataSize() + 4 + 8
 }
@@ -195,22 +195,22 @@ func (v *Vector) Serialize() ([]byte, error) {
 	if v == nil {
 		return nil, errors.New("cannot serialize nil vector")
 	}
-	
+
 	// Calculate total size
 	size := v.Size()
 	buf := make([]byte, 0, size)
-	
+
 	// Serialize ID
 	idBytes := []byte(v.ID)
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(idBytes)))
 	buf = append(buf, idBytes...)
-	
+
 	// Serialize Data
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(v.Data)))
 	for _, val := range v.Data {
 		buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(val))
 	}
-	
+
 	// Serialize Metadata (simplified)
 	if v.Metadata == nil {
 		buf = binary.BigEndian.AppendUint32(buf, 0)
@@ -219,11 +219,11 @@ func (v *Vector) Serialize() ([]byte, error) {
 		buf = binary.BigEndian.AppendUint32(buf, uint32(len(v.Metadata)))
 		// Placeholder for metadata serialization
 	}
-	
+
 	// Serialize ClusterID and Timestamp
 	buf = binary.BigEndian.AppendUint32(buf, v.ClusterID)
 	buf = binary.BigEndian.AppendUint64(buf, uint64(v.Timestamp))
-	
+
 	return buf, nil
 }
 
@@ -232,13 +232,13 @@ func Deserialize(data []byte) (*Vector, error) {
 	if len(data) < 12 { // Minimum size check
 		return nil, errors.New("insufficient data for vector deserialization")
 	}
-	
+
 	vector := &Vector{
 		Metadata: make(map[string]interface{}),
 	}
-	
+
 	offset := 0
-	
+
 	// Deserialize ID
 	idLen := binary.BigEndian.Uint32(data[offset : offset+4])
 	offset += 4
@@ -247,7 +247,7 @@ func Deserialize(data []byte) (*Vector, error) {
 	}
 	vector.ID = string(data[offset : offset+int(idLen)])
 	offset += int(idLen)
-	
+
 	// Deserialize Data
 	dataLen := binary.BigEndian.Uint32(data[offset : offset+4])
 	offset += 4
@@ -260,13 +260,13 @@ func Deserialize(data []byte) (*Vector, error) {
 		vector.Data[i] = math.Float32frombits(bits)
 		offset += 4
 	}
-	
+
 	// Deserialize Metadata (simplified)
 	metadataLen := binary.BigEndian.Uint32(data[offset : offset+4])
 	offset += 4
 	// Skip metadata for now (would implement proper deserialization in practice)
 	offset += int(metadataLen) * 16 // Approximate
-	
+
 	// Deserialize ClusterID and Timestamp
 	if offset+12 > len(data) {
 		return nil, errors.New("insufficient data for cluster ID and timestamp")
@@ -274,6 +274,6 @@ func Deserialize(data []byte) (*Vector, error) {
 	vector.ClusterID = binary.BigEndian.Uint32(data[offset : offset+4])
 	offset += 4
 	vector.Timestamp = int64(binary.BigEndian.Uint64(data[offset : offset+8]))
-	
+
 	return vector, nil
 }

--- a/kubernetes/vxdb-deployment.yaml
+++ b/kubernetes/vxdb-deployment.yaml
@@ -1,29 +1,29 @@
-# VexDB Kubernetes Deployment Configuration
-# This configuration deploys all three VexDB services with production-ready settings
+# VxDB Kubernetes Deployment Configuration
+# This configuration deploys all three VxDB services with production-ready settings
 
 ---
-# Namespace for VexDB components
+# Namespace for VxDB components
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: vexdb
+  name: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: namespace
 
 ---
-# ConfigMap for VexDB Insert Service configuration
+# ConfigMap for VxDB Insert Service configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vexinsert-config
-  namespace: vexdb
+  name: vxinsert-config
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
 data:
   config.yaml: |
-    # VexDB Insert Service Configuration
+    # VxDB Insert Service Configuration
     server:
       host: "0.0.0.0"
       port: 8080
@@ -43,14 +43,14 @@ data:
       host: "0.0.0.0"
       port: 9091
       path: "/metrics"
-      namespace: "vexdb"
+      namespace: "vxdb"
       subsystem: "insert"
     
     cluster:
-      name: "vexdb-cluster"
-      data_dir: "/var/lib/vexdb/data"
-      wal_dir: "/var/lib/vexdb/wal"
-      snapshot_dir: "/var/lib/vexdb/snapshots"
+      name: "vxdb-cluster"
+      data_dir: "/var/lib/vxdb/data"
+      wal_dir: "/var/lib/vxdb/wal"
+      snapshot_dir: "/var/lib/vxdb/snapshots"
     
     replication:
       enabled: true
@@ -97,18 +97,18 @@ data:
         by_ip: true
 
 ---
-# ConfigMap for VexDB Storage Service configuration
+# ConfigMap for VxDB Storage Service configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vexstorage-config
-  namespace: vexdb
+  name: vxstorage-config
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
 data:
   config.yaml: |
-    # VexDB Storage Service Configuration
+    # VxDB Storage Service Configuration
     server:
       host: "0.0.0.0"
       port: 8082
@@ -128,19 +128,19 @@ data:
       host: "0.0.0.0"
       port: 9094
       path: "/metrics"
-      namespace: "vexdb"
+      namespace: "vxdb"
       subsystem: "storage"
     
     cluster:
-      name: "vexdb-cluster"
-      data_dir: "/var/lib/vexdb/data"
-      wal_dir: "/var/lib/vexdb/wal"
-      snapshot_dir: "/var/lib/vexdb/snapshots"
+      name: "vxdb-cluster"
+      data_dir: "/var/lib/vxdb/data"
+      wal_dir: "/var/lib/vxdb/wal"
+      snapshot_dir: "/var/lib/vxdb/snapshots"
     
     storage:
-      data_dir: "/var/lib/vexdb/storage"
-      wal_dir: "/var/lib/vexdb/wal"
-      temp_dir: "/var/lib/vexdb/temp"
+      data_dir: "/var/lib/vxdb/storage"
+      wal_dir: "/var/lib/vxdb/wal"
+      temp_dir: "/var/lib/vxdb/temp"
       
       segment:
         max_vectors: 10000
@@ -198,18 +198,18 @@ data:
         enabled: false
 
 ---
-# ConfigMap for VexDB Search Service configuration
+# ConfigMap for VxDB Search Service configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vexsearch-config
-  namespace: vexdb
+  name: vxsearch-config
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
 data:
   config.yaml: |
-    # VexDB Search Service Configuration
+    # VxDB Search Service Configuration
     server:
       host: "0.0.0.0"
       port: 8083
@@ -229,14 +229,14 @@ data:
       host: "0.0.0.0"
       port: 9097
       path: "/metrics"
-      namespace: "vexdb"
+      namespace: "vxdb"
       subsystem: "search"
     
     cluster:
-      name: "vexdb-cluster"
-      data_dir: "/var/lib/vexdb/data"
-      wal_dir: "/var/lib/vexdb/wal"
-      snapshot_dir: "/var/lib/vexdb/snapshots"
+      name: "vxdb-cluster"
+      data_dir: "/var/lib/vxdb/data"
+      wal_dir: "/var/lib/vxdb/wal"
+      snapshot_dir: "/var/lib/vxdb/snapshots"
     
     engine:
       max_results: 100
@@ -347,14 +347,14 @@ data:
         max_results: 1000
 
 ---
-# Secret for VexDB API keys and certificates
+# Secret for VxDB API keys and certificates
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vexdb-secrets
-  namespace: vexdb
+  name: vxdb-secrets
+  namespace: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: secrets
 type: Opaque
 data:
@@ -365,19 +365,19 @@ data:
   tls-key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
 
 ---
-# Service for VexDB Insert Service
+# Service for VxDB Insert Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: vexinsert-service
-  namespace: vexdb
+  name: vxinsert-service
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
 spec:
   selector:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
   ports:
     - name: http
       port: 8080
@@ -406,19 +406,19 @@ spec:
   type: ClusterIP
 
 ---
-# Service for VexDB Storage Service
+# Service for VxDB Storage Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: vexstorage-service
-  namespace: vexdb
+  name: vxstorage-service
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
 spec:
   selector:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
   ports:
     - name: http
       port: 8082
@@ -439,19 +439,19 @@ spec:
   type: ClusterIP
 
 ---
-# Service for VexDB Search Service
+# Service for VxDB Search Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: vexsearch-service
-  namespace: vexdb
+  name: vxsearch-service
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
 spec:
   selector:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
   ports:
     - name: http
       port: 8083
@@ -472,31 +472,31 @@ spec:
   type: ClusterIP
 
 ---
-# Deployment for VexDB Insert Service
+# Deployment for VxDB Insert Service
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vexinsert-deployment
-  namespace: vexdb
+  name: vxinsert-deployment
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vexdb
-      component: vexinsert
+      app: vxdb
+      component: vxinsert
   template:
     metadata:
       labels:
-        app: vexdb
-        component: vexinsert
+        app: vxdb
+        component: vxinsert
     spec:
-      serviceAccountName: vexdb-service-account
+      serviceAccountName: vxdb-service-account
       containers:
-        - name: vexinsert
-          image: vexdb/vexinsert:latest
+        - name: vxinsert
+          image: vxdb/vxinsert:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -512,8 +512,8 @@ spec:
             - containerPort: 6379
               name: redis
           env:
-            - name: VEXDB_CONFIG_FILE
-              value: "/etc/vexdb/config.yaml"
+            - name: VXDB_CONFIG_FILE
+              value: "/etc/vxdb/config.yaml"
             - name: GIN_MODE
               value: "release"
             - name: POD_NAME
@@ -530,18 +530,18 @@ spec:
                   fieldPath: status.podIP
           volumeMounts:
             - name: config
-              mountPath: /etc/vexdb
+              mountPath: /etc/vxdb
               readOnly: true
             - name: data
-              mountPath: /var/lib/vexdb/data
+              mountPath: /var/lib/vxdb/data
             - name: wal
-              mountPath: /var/lib/vexdb/wal
+              mountPath: /var/lib/vxdb/wal
             - name: snapshots
-              mountPath: /var/lib/vexdb/snapshots
+              mountPath: /var/lib/vxdb/snapshots
             - name: buffer
-              mountPath: /var/lib/vexdb/buffer
+              mountPath: /var/lib/vxdb/buffer
             - name: logs
-              mountPath: /var/log/vexdb
+              mountPath: /var/log/vxdb
           resources:
             requests:
               memory: "512Mi"
@@ -568,49 +568,49 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: vexinsert-config
+            name: vxinsert-config
         - name: data
           persistentVolumeClaim:
-            claimName: vexinsert-data-pvc
+            claimName: vxinsert-data-pvc
         - name: wal
           persistentVolumeClaim:
-            claimName: vexinsert-wal-pvc
+            claimName: vxinsert-wal-pvc
         - name: snapshots
           persistentVolumeClaim:
-            claimName: vexinsert-snapshots-pvc
+            claimName: vxinsert-snapshots-pvc
         - name: buffer
           persistentVolumeClaim:
-            claimName: vexinsert-buffer-pvc
+            claimName: vxinsert-buffer-pvc
         - name: logs
           persistentVolumeClaim:
-            claimName: vexinsert-logs-pvc
+            claimName: vxinsert-logs-pvc
 
 ---
-# Deployment for VexDB Storage Service
+# Deployment for VxDB Storage Service
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vexstorage-deployment
-  namespace: vexdb
+  name: vxstorage-deployment
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vexdb
-      component: vexstorage
+      app: vxdb
+      component: vxstorage
   template:
     metadata:
       labels:
-        app: vexdb
-        component: vexstorage
+        app: vxdb
+        component: vxstorage
     spec:
-      serviceAccountName: vexdb-service-account
+      serviceAccountName: vxdb-service-account
       containers:
-        - name: vexstorage
-          image: vexdb/vexstorage:latest
+        - name: vxstorage
+          image: vxdb/vxstorage:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8082
@@ -622,8 +622,8 @@ spec:
             - containerPort: 9096
               name: grpc
           env:
-            - name: VEXDB_CONFIG_FILE
-              value: "/etc/vexdb/config.yaml"
+            - name: VXDB_CONFIG_FILE
+              value: "/etc/vxdb/config.yaml"
             - name: GIN_MODE
               value: "release"
             - name: POD_NAME
@@ -640,24 +640,24 @@ spec:
                   fieldPath: status.podIP
           volumeMounts:
             - name: config
-              mountPath: /etc/vexdb
+              mountPath: /etc/vxdb
               readOnly: true
             - name: data
-              mountPath: /var/lib/vexdb/data
+              mountPath: /var/lib/vxdb/data
             - name: wal
-              mountPath: /var/lib/vexdb/wal
+              mountPath: /var/lib/vxdb/wal
             - name: snapshots
-              mountPath: /var/lib/vexdb/snapshots
+              mountPath: /var/lib/vxdb/snapshots
             - name: storage
-              mountPath: /var/lib/vexdb/storage
+              mountPath: /var/lib/vxdb/storage
             - name: temp
-              mountPath: /var/lib/vexdb/temp
+              mountPath: /var/lib/vxdb/temp
             - name: manifest
-              mountPath: /var/lib/vexdb/manifest
+              mountPath: /var/lib/vxdb/manifest
             - name: backups
-              mountPath: /var/lib/vexdb/backups
+              mountPath: /var/lib/vxdb/backups
             - name: logs
-              mountPath: /var/log/vexdb
+              mountPath: /var/log/vxdb
           resources:
             requests:
               memory: "1Gi"
@@ -684,58 +684,58 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: vexstorage-config
+            name: vxstorage-config
         - name: data
           persistentVolumeClaim:
-            claimName: vexstorage-data-pvc
+            claimName: vxstorage-data-pvc
         - name: wal
           persistentVolumeClaim:
-            claimName: vexstorage-wal-pvc
+            claimName: vxstorage-wal-pvc
         - name: snapshots
           persistentVolumeClaim:
-            claimName: vexstorage-snapshots-pvc
+            claimName: vxstorage-snapshots-pvc
         - name: storage
           persistentVolumeClaim:
-            claimName: vexstorage-storage-pvc
+            claimName: vxstorage-storage-pvc
         - name: temp
           persistentVolumeClaim:
-            claimName: vexstorage-temp-pvc
+            claimName: vxstorage-temp-pvc
         - name: manifest
           persistentVolumeClaim:
-            claimName: vexstorage-manifest-pvc
+            claimName: vxstorage-manifest-pvc
         - name: backups
           persistentVolumeClaim:
-            claimName: vexstorage-backups-pvc
+            claimName: vxstorage-backups-pvc
         - name: logs
           persistentVolumeClaim:
-            claimName: vexstorage-logs-pvc
+            claimName: vxstorage-logs-pvc
 
 ---
-# Deployment for VexDB Search Service
+# Deployment for VxDB Search Service
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vexsearch-deployment
-  namespace: vexdb
+  name: vxsearch-deployment
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vexdb
-      component: vexsearch
+      app: vxdb
+      component: vxsearch
   template:
     metadata:
       labels:
-        app: vexdb
-        component: vexsearch
+        app: vxdb
+        component: vxsearch
     spec:
-      serviceAccountName: vexdb-service-account
+      serviceAccountName: vxdb-service-account
       containers:
-        - name: vexsearch
-          image: vexdb/vexsearch:latest
+        - name: vxsearch
+          image: vxdb/vxsearch:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8083
@@ -747,8 +747,8 @@ spec:
             - containerPort: 9099
               name: grpc
           env:
-            - name: VEXDB_CONFIG_FILE
-              value: "/etc/vexdb/config.yaml"
+            - name: VXDB_CONFIG_FILE
+              value: "/etc/vxdb/config.yaml"
             - name: GIN_MODE
               value: "release"
             - name: POD_NAME
@@ -765,18 +765,18 @@ spec:
                   fieldPath: status.podIP
           volumeMounts:
             - name: config
-              mountPath: /etc/vexdb
+              mountPath: /etc/vxdb
               readOnly: true
             - name: data
-              mountPath: /var/lib/vexdb/data
+              mountPath: /var/lib/vxdb/data
             - name: wal
-              mountPath: /var/lib/vexdb/wal
+              mountPath: /var/lib/vxdb/wal
             - name: snapshots
-              mountPath: /var/lib/vexdb/snapshots
+              mountPath: /var/lib/vxdb/snapshots
             - name: cache
-              mountPath: /var/lib/vexdb/cache
+              mountPath: /var/lib/vxdb/cache
             - name: logs
-              mountPath: /var/log/vexdb
+              mountPath: /var/log/vxdb
           resources:
             requests:
               memory: "1Gi"
@@ -803,43 +803,43 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: vexsearch-config
+            name: vxsearch-config
         - name: data
           persistentVolumeClaim:
-            claimName: vexsearch-data-pvc
+            claimName: vxsearch-data-pvc
         - name: wal
           persistentVolumeClaim:
-            claimName: vexsearch-wal-pvc
+            claimName: vxsearch-wal-pvc
         - name: snapshots
           persistentVolumeClaim:
-            claimName: vexsearch-snapshots-pvc
+            claimName: vxsearch-snapshots-pvc
         - name: cache
           persistentVolumeClaim:
-            claimName: vexsearch-cache-pvc
+            claimName: vxsearch-cache-pvc
         - name: logs
           persistentVolumeClaim:
-            claimName: vexsearch-logs-pvc
+            claimName: vxsearch-logs-pvc
 
 ---
-# Service Account for VexDB services
+# Service Account for VxDB services
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vexdb-service-account
-  namespace: vexdb
+  name: vxdb-service-account
+  namespace: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: service-account
 
 ---
-# Role for VexDB services
+# Role for VxDB services
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: vexdb-role
-  namespace: vexdb
+  name: vxdb-role
+  namespace: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: role
 rules:
   - apiGroups: [""]
@@ -853,39 +853,39 @@ rules:
     verbs: ["get", "list"]
 
 ---
-# Role Binding for VexDB services
+# Role Binding for VxDB services
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: vexdb-role-binding
-  namespace: vexdb
+  name: vxdb-role-binding
+  namespace: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: role-binding
 subjects:
   - kind: ServiceAccount
-    name: vexdb-service-account
-    namespace: vexdb
+    name: vxdb-service-account
+    namespace: vxdb
 roleRef:
   kind: Role
-  name: vexdb-role
+  name: vxdb-role
   apiGroup: rbac.authorization.k8s.io
 
 ---
-# Horizontal Pod Autoscaler for VexDB Insert Service
+# Horizontal Pod Autoscaler for VxDB Insert Service
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: vexinsert-hpa
-  namespace: vexdb
+  name: vxinsert-hpa
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: vexinsert-deployment
+    name: vxinsert-deployment
   minReplicas: 3
   maxReplicas: 10
   metrics:
@@ -903,20 +903,20 @@ spec:
           averageUtilization: 80
 
 ---
-# Horizontal Pod Autoscaler for VexDB Storage Service
+# Horizontal Pod Autoscaler for VxDB Storage Service
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: vexstorage-hpa
-  namespace: vexdb
+  name: vxstorage-hpa
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: vexstorage-deployment
+    name: vxstorage-deployment
   minReplicas: 3
   maxReplicas: 10
   metrics:
@@ -934,20 +934,20 @@ spec:
           averageUtilization: 80
 
 ---
-# Horizontal Pod Autoscaler for VexDB Search Service
+# Horizontal Pod Autoscaler for VxDB Search Service
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: vexsearch-hpa
-  namespace: vexdb
+  name: vxsearch-hpa
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: vexsearch-deployment
+    name: vxsearch-deployment
   minReplicas: 3
   maxReplicas: 10
   metrics:
@@ -965,15 +965,15 @@ spec:
           averageUtilization: 80
 
 ---
-# Persistent Volume Claims for VexDB Insert Service
+# Persistent Volume Claims for VxDB Insert Service
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexinsert-data-pvc
-  namespace: vexdb
+  name: vxinsert-data-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
     volume: data
 spec:
   accessModes:
@@ -987,11 +987,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexinsert-wal-pvc
-  namespace: vexdb
+  name: vxinsert-wal-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
     volume: wal
 spec:
   accessModes:
@@ -1005,11 +1005,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexinsert-snapshots-pvc
-  namespace: vexdb
+  name: vxinsert-snapshots-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
     volume: snapshots
 spec:
   accessModes:
@@ -1023,11 +1023,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexinsert-buffer-pvc
-  namespace: vexdb
+  name: vxinsert-buffer-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
     volume: buffer
 spec:
   accessModes:
@@ -1041,11 +1041,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexinsert-logs-pvc
-  namespace: vexdb
+  name: vxinsert-logs-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexinsert
+    app: vxdb
+    component: vxinsert
     volume: logs
 spec:
   accessModes:
@@ -1056,15 +1056,15 @@ spec:
   storageClassName: standard
 
 ---
-# Persistent Volume Claims for VexDB Storage Service
+# Persistent Volume Claims for VxDB Storage Service
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-data-pvc
-  namespace: vexdb
+  name: vxstorage-data-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: data
 spec:
   accessModes:
@@ -1078,11 +1078,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-wal-pvc
-  namespace: vexdb
+  name: vxstorage-wal-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: wal
 spec:
   accessModes:
@@ -1096,11 +1096,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-snapshots-pvc
-  namespace: vexdb
+  name: vxstorage-snapshots-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: snapshots
 spec:
   accessModes:
@@ -1114,11 +1114,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-storage-pvc
-  namespace: vexdb
+  name: vxstorage-storage-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: storage
 spec:
   accessModes:
@@ -1132,11 +1132,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-temp-pvc
-  namespace: vexdb
+  name: vxstorage-temp-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: temp
 spec:
   accessModes:
@@ -1150,11 +1150,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-manifest-pvc
-  namespace: vexdb
+  name: vxstorage-manifest-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: manifest
 spec:
   accessModes:
@@ -1168,11 +1168,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-backups-pvc
-  namespace: vexdb
+  name: vxstorage-backups-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: backups
 spec:
   accessModes:
@@ -1186,11 +1186,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexstorage-logs-pvc
-  namespace: vexdb
+  name: vxstorage-logs-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexstorage
+    app: vxdb
+    component: vxstorage
     volume: logs
 spec:
   accessModes:
@@ -1201,15 +1201,15 @@ spec:
   storageClassName: standard
 
 ---
-# Persistent Volume Claims for VexDB Search Service
+# Persistent Volume Claims for VxDB Search Service
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexsearch-data-pvc
-  namespace: vexdb
+  name: vxsearch-data-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
     volume: data
 spec:
   accessModes:
@@ -1223,11 +1223,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexsearch-wal-pvc
-  namespace: vexdb
+  name: vxsearch-wal-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
     volume: wal
 spec:
   accessModes:
@@ -1241,11 +1241,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexsearch-snapshots-pvc
-  namespace: vexdb
+  name: vxsearch-snapshots-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
     volume: snapshots
 spec:
   accessModes:
@@ -1259,11 +1259,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexsearch-cache-pvc
-  namespace: vexdb
+  name: vxsearch-cache-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
     volume: cache
 spec:
   accessModes:
@@ -1277,11 +1277,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: vexsearch-logs-pvc
-  namespace: vexdb
+  name: vxsearch-logs-pvc
+  namespace: vxdb
   labels:
-    app: vexdb
-    component: vexsearch
+    app: vxdb
+    component: vxsearch
     volume: logs
 spec:
   accessModes:
@@ -1292,14 +1292,14 @@ spec:
   storageClassName: standard
 
 ---
-# Ingress for VexDB services
+# Ingress for VxDB services
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: vexdb-ingress
-  namespace: vexdb
+  name: vxdb-ingress
+  namespace: vxdb
   labels:
-    app: vexdb
+    app: vxdb
     component: ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
@@ -1308,30 +1308,30 @@ metadata:
 spec:
   tls:
     - hosts:
-        - vexdb.example.com
-      secretName: vexdb-tls
+        - vxdb.example.com
+      secretName: vxdb-tls
   rules:
-    - host: vexdb.example.com
+    - host: vxdb.example.com
       http:
         paths:
           - path: /insert
             pathType: Prefix
             backend:
               service:
-                name: vexinsert-service
+                name: vxinsert-service
                 port:
                   number: 8080
           - path: /storage
             pathType: Prefix
             backend:
               service:
-                name: vexstorage-service
+                name: vxstorage-service
                 port:
                   number: 8082
           - path: /search
             pathType: Prefix
             backend:
               service:
-                name: vexsearch-service
+                name: vxsearch-service
                 port:
                   number: 8083

--- a/proto/vxdb.pb.go
+++ b/proto/vxdb.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.8
 // 	protoc        v3.21.12
-// source: vexdb.proto
+// source: vxdb.proto
 
 package proto
 
@@ -37,7 +37,7 @@ type Vector struct {
 
 func (x *Vector) Reset() {
 	*x = Vector{}
-	mi := &file_vexdb_proto_msgTypes[0]
+	mi := &file_vxdb_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -49,7 +49,7 @@ func (x *Vector) String() string {
 func (*Vector) ProtoMessage() {}
 
 func (x *Vector) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[0]
+	mi := &file_vxdb_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62,7 +62,7 @@ func (x *Vector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Vector.ProtoReflect.Descriptor instead.
 func (*Vector) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{0}
+	return file_vxdb_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Vector) GetId() string {
@@ -110,7 +110,7 @@ type VectorBatch struct {
 
 func (x *VectorBatch) Reset() {
 	*x = VectorBatch{}
-	mi := &file_vexdb_proto_msgTypes[1]
+	mi := &file_vxdb_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -122,7 +122,7 @@ func (x *VectorBatch) String() string {
 func (*VectorBatch) ProtoMessage() {}
 
 func (x *VectorBatch) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[1]
+	mi := &file_vxdb_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -135,7 +135,7 @@ func (x *VectorBatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VectorBatch.ProtoReflect.Descriptor instead.
 func (*VectorBatch) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{1}
+	return file_vxdb_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *VectorBatch) GetVectors() []*Vector {
@@ -159,7 +159,7 @@ type InsertRequest struct {
 
 func (x *InsertRequest) Reset() {
 	*x = InsertRequest{}
-	mi := &file_vexdb_proto_msgTypes[2]
+	mi := &file_vxdb_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -171,7 +171,7 @@ func (x *InsertRequest) String() string {
 func (*InsertRequest) ProtoMessage() {}
 
 func (x *InsertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[2]
+	mi := &file_vxdb_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -184,7 +184,7 @@ func (x *InsertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsertRequest.ProtoReflect.Descriptor instead.
 func (*InsertRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{2}
+	return file_vxdb_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *InsertRequest) GetRequest() isInsertRequest_Request {
@@ -241,7 +241,7 @@ type InsertResponse struct {
 
 func (x *InsertResponse) Reset() {
 	*x = InsertResponse{}
-	mi := &file_vexdb_proto_msgTypes[3]
+	mi := &file_vxdb_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -253,7 +253,7 @@ func (x *InsertResponse) String() string {
 func (*InsertResponse) ProtoMessage() {}
 
 func (x *InsertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[3]
+	mi := &file_vxdb_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -266,7 +266,7 @@ func (x *InsertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsertResponse.ProtoReflect.Descriptor instead.
 func (*InsertResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{3}
+	return file_vxdb_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *InsertResponse) GetSuccess() bool {
@@ -312,7 +312,7 @@ type SearchRequest struct {
 
 func (x *SearchRequest) Reset() {
 	*x = SearchRequest{}
-	mi := &file_vexdb_proto_msgTypes[4]
+	mi := &file_vxdb_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +324,7 @@ func (x *SearchRequest) String() string {
 func (*SearchRequest) ProtoMessage() {}
 
 func (x *SearchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[4]
+	mi := &file_vxdb_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -337,7 +337,7 @@ func (x *SearchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchRequest.ProtoReflect.Descriptor instead.
 func (*SearchRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{4}
+	return file_vxdb_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SearchRequest) GetQueryVector() *Vector {
@@ -396,7 +396,7 @@ type SearchResult struct {
 
 func (x *SearchResult) Reset() {
 	*x = SearchResult{}
-	mi := &file_vexdb_proto_msgTypes[5]
+	mi := &file_vxdb_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -408,7 +408,7 @@ func (x *SearchResult) String() string {
 func (*SearchResult) ProtoMessage() {}
 
 func (x *SearchResult) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[5]
+	mi := &file_vxdb_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -421,7 +421,7 @@ func (x *SearchResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchResult.ProtoReflect.Descriptor instead.
 func (*SearchResult) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{5}
+	return file_vxdb_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SearchResult) GetVector() *Vector {
@@ -473,7 +473,7 @@ type SearchResponse struct {
 
 func (x *SearchResponse) Reset() {
 	*x = SearchResponse{}
-	mi := &file_vexdb_proto_msgTypes[6]
+	mi := &file_vxdb_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -485,7 +485,7 @@ func (x *SearchResponse) String() string {
 func (*SearchResponse) ProtoMessage() {}
 
 func (x *SearchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[6]
+	mi := &file_vxdb_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -498,7 +498,7 @@ func (x *SearchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchResponse.ProtoReflect.Descriptor instead.
 func (*SearchResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{6}
+	return file_vxdb_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SearchResponse) GetSuccess() bool {
@@ -547,7 +547,7 @@ type DeleteRequest struct {
 
 func (x *DeleteRequest) Reset() {
 	*x = DeleteRequest{}
-	mi := &file_vexdb_proto_msgTypes[7]
+	mi := &file_vxdb_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -559,7 +559,7 @@ func (x *DeleteRequest) String() string {
 func (*DeleteRequest) ProtoMessage() {}
 
 func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[7]
+	mi := &file_vxdb_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -572,7 +572,7 @@ func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{7}
+	return file_vxdb_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DeleteRequest) GetVectorIds() []string {
@@ -602,7 +602,7 @@ type DeleteResponse struct {
 
 func (x *DeleteResponse) Reset() {
 	*x = DeleteResponse{}
-	mi := &file_vexdb_proto_msgTypes[8]
+	mi := &file_vxdb_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +614,7 @@ func (x *DeleteResponse) String() string {
 func (*DeleteResponse) ProtoMessage() {}
 
 func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[8]
+	mi := &file_vxdb_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +627,7 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{8}
+	return file_vxdb_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DeleteResponse) GetSuccess() bool {
@@ -672,7 +672,7 @@ type ClusterInfo struct {
 
 func (x *ClusterInfo) Reset() {
 	*x = ClusterInfo{}
-	mi := &file_vexdb_proto_msgTypes[9]
+	mi := &file_vxdb_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -684,7 +684,7 @@ func (x *ClusterInfo) String() string {
 func (*ClusterInfo) ProtoMessage() {}
 
 func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[9]
+	mi := &file_vxdb_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -697,7 +697,7 @@ func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterInfo.ProtoReflect.Descriptor instead.
 func (*ClusterInfo) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{9}
+	return file_vxdb_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ClusterInfo) GetId() string {
@@ -753,7 +753,7 @@ type NodeInfo struct {
 
 func (x *NodeInfo) Reset() {
 	*x = NodeInfo{}
-	mi := &file_vexdb_proto_msgTypes[10]
+	mi := &file_vxdb_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -765,7 +765,7 @@ func (x *NodeInfo) String() string {
 func (*NodeInfo) ProtoMessage() {}
 
 func (x *NodeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[10]
+	mi := &file_vxdb_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -778,7 +778,7 @@ func (x *NodeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeInfo.ProtoReflect.Descriptor instead.
 func (*NodeInfo) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{10}
+	return file_vxdb_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *NodeInfo) GetId() string {
@@ -858,7 +858,7 @@ type ClusterStatus struct {
 
 func (x *ClusterStatus) Reset() {
 	*x = ClusterStatus{}
-	mi := &file_vexdb_proto_msgTypes[11]
+	mi := &file_vxdb_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -870,7 +870,7 @@ func (x *ClusterStatus) String() string {
 func (*ClusterStatus) ProtoMessage() {}
 
 func (x *ClusterStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[11]
+	mi := &file_vxdb_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -883,7 +883,7 @@ func (x *ClusterStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterStatus.ProtoReflect.Descriptor instead.
 func (*ClusterStatus) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{11}
+	return file_vxdb_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ClusterStatus) GetClusters() []*ClusterInfo {
@@ -931,7 +931,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_vexdb_proto_msgTypes[12]
+	mi := &file_vxdb_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -943,7 +943,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[12]
+	mi := &file_vxdb_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -956,7 +956,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{12}
+	return file_vxdb_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HealthCheckRequest) GetDetailed() bool {
@@ -980,7 +980,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_vexdb_proto_msgTypes[13]
+	mi := &file_vxdb_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -992,7 +992,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[13]
+	mi := &file_vxdb_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1005,7 +1005,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{13}
+	return file_vxdb_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HealthCheckResponse) GetHealthy() bool {
@@ -1055,7 +1055,7 @@ type MetricsRequest struct {
 
 func (x *MetricsRequest) Reset() {
 	*x = MetricsRequest{}
-	mi := &file_vexdb_proto_msgTypes[14]
+	mi := &file_vxdb_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1067,7 +1067,7 @@ func (x *MetricsRequest) String() string {
 func (*MetricsRequest) ProtoMessage() {}
 
 func (x *MetricsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[14]
+	mi := &file_vxdb_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1080,7 +1080,7 @@ func (x *MetricsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricsRequest.ProtoReflect.Descriptor instead.
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{14}
+	return file_vxdb_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *MetricsRequest) GetMetricType() string {
@@ -1118,7 +1118,7 @@ type MetricsResponse struct {
 
 func (x *MetricsResponse) Reset() {
 	*x = MetricsResponse{}
-	mi := &file_vexdb_proto_msgTypes[15]
+	mi := &file_vxdb_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1130,7 +1130,7 @@ func (x *MetricsResponse) String() string {
 func (*MetricsResponse) ProtoMessage() {}
 
 func (x *MetricsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[15]
+	mi := &file_vxdb_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1143,7 +1143,7 @@ func (x *MetricsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricsResponse.ProtoReflect.Descriptor instead.
 func (*MetricsResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{15}
+	return file_vxdb_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *MetricsResponse) GetSuccess() bool {
@@ -1192,7 +1192,7 @@ type ConfigUpdateRequest struct {
 
 func (x *ConfigUpdateRequest) Reset() {
 	*x = ConfigUpdateRequest{}
-	mi := &file_vexdb_proto_msgTypes[16]
+	mi := &file_vxdb_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1204,7 @@ func (x *ConfigUpdateRequest) String() string {
 func (*ConfigUpdateRequest) ProtoMessage() {}
 
 func (x *ConfigUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[16]
+	mi := &file_vxdb_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1217,7 @@ func (x *ConfigUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ConfigUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{16}
+	return file_vxdb_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ConfigUpdateRequest) GetConfigUpdates() map[string]string {
@@ -1247,7 +1247,7 @@ type ConfigUpdateResponse struct {
 
 func (x *ConfigUpdateResponse) Reset() {
 	*x = ConfigUpdateResponse{}
-	mi := &file_vexdb_proto_msgTypes[17]
+	mi := &file_vxdb_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1259,7 +1259,7 @@ func (x *ConfigUpdateResponse) String() string {
 func (*ConfigUpdateResponse) ProtoMessage() {}
 
 func (x *ConfigUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_vexdb_proto_msgTypes[17]
+	mi := &file_vxdb_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1272,7 +1272,7 @@ func (x *ConfigUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigUpdateResponse.ProtoReflect.Descriptor instead.
 func (*ConfigUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_vexdb_proto_rawDescGZIP(), []int{17}
+	return file_vxdb_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ConfigUpdateResponse) GetSuccess() bool {
@@ -1303,15 +1303,15 @@ func (x *ConfigUpdateResponse) GetFailedUpdates() map[string]string {
 	return nil
 }
 
-var File_vexdb_proto protoreflect.FileDescriptor
+var File_vxdb_proto protoreflect.FileDescriptor
 
-const file_vexdb_proto_rawDesc = "" +
+const file_vxdb_proto_rawDesc = "" +
 	"\n" +
-	"\vvexdb.proto\x12\x05vexdb\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xfb\x01\n" +
+	"\vvxdb.proto\x12\x05vxdb\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xfb\x01\n" +
 	"\x06Vector\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04data\x18\x02 \x03(\x02R\x04data\x127\n" +
-	"\bmetadata\x18\x03 \x03(\v2\x1b.vexdb.Vector.MetadataEntryR\bmetadata\x12\x1d\n" +
+	"\bmetadata\x18\x03 \x03(\v2\x1b.vxdb.Vector.MetadataEntryR\bmetadata\x12\x1d\n" +
 	"\n" +
 	"cluster_id\x18\x04 \x01(\rR\tclusterId\x128\n" +
 	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x1a;\n" +
@@ -1319,33 +1319,33 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"6\n" +
 	"\vVectorBatch\x12'\n" +
-	"\avectors\x18\x01 \x03(\v2\r.vexdb.VectorR\avectors\"o\n" +
+	"\avectors\x18\x01 \x03(\v2\r.vxdb.VectorR\avectors\"o\n" +
 	"\rInsertRequest\x12'\n" +
-	"\x06vector\x18\x01 \x01(\v2\r.vexdb.VectorH\x00R\x06vector\x12*\n" +
-	"\x05batch\x18\x02 \x01(\v2\x12.vexdb.VectorBatchH\x00R\x05batchB\t\n" +
+	"\x06vector\x18\x01 \x01(\v2\r.vxdb.VectorH\x00R\x06vector\x12*\n" +
+	"\x05batch\x18\x02 \x01(\v2\x12.vxdb.VectorBatchH\x00R\x05batchB\t\n" +
 	"\arequest\"\xe1\x01\n" +
 	"\x0eInsertResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
 	"\n" +
 	"vector_ids\x18\x03 \x03(\tR\tvectorIds\x12?\n" +
-	"\bmetadata\x18\x04 \x03(\v2#.vexdb.InsertResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x04 \x03(\v2#.vxdb.InsertResponse.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe0\x02\n" +
 	"\rSearchRequest\x120\n" +
-	"\fquery_vector\x18\x01 \x01(\v2\r.vexdb.VectorR\vqueryVector\x12\f\n" +
+	"\fquery_vector\x18\x01 \x01(\v2\r.vxdb.VectorR\vqueryVector\x12\f\n" +
 	"\x01k\x18\x02 \x01(\x05R\x01k\x12\x1f\n" +
 	"\vcluster_ids\x18\x03 \x03(\tR\n" +
 	"clusterIds\x12Q\n" +
-	"\x0fmetadata_filter\x18\x04 \x03(\v2(.vexdb.SearchRequest.MetadataFilterEntryR\x0emetadataFilter\x12)\n" +
+	"\x0fmetadata_filter\x18\x04 \x03(\v2(.vxdb.SearchRequest.MetadataFilterEntryR\x0emetadataFilter\x12)\n" +
 	"\x10include_metadata\x18\x05 \x01(\bR\x0fincludeMetadata\x12-\n" +
 	"\x12distance_threshold\x18\x06 \x01(\x02R\x11distanceThreshold\x1aA\n" +
 	"\x13MetadataFilterEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9f\x01\n" +
 	"\fSearchResult\x12%\n" +
-	"\x06vector\x18\x01 \x01(\v2\r.vexdb.VectorR\x06vector\x12\x1a\n" +
+	"\x06vector\x18\x01 \x01(\v2\r.vxdb.VectorR\x06vector\x12\x1a\n" +
 	"\bdistance\x18\x02 \x01(\x02R\bdistance\x12\x14\n" +
 	"\x05score\x18\x03 \x01(\x02R\x05score\x12\x1d\n" +
 	"\n" +
@@ -1354,16 +1354,16 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x0eSearchResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12-\n" +
-	"\aresults\x18\x03 \x03(\v2\x13.vexdb.SearchResultR\aresults\x12#\n" +
+	"\aresults\x18\x03 \x03(\v2\x13.vxdb.SearchResultR\aresults\x12#\n" +
 	"\rtotal_results\x18\x04 \x01(\x03R\ftotalResults\x12?\n" +
-	"\bmetadata\x18\x05 \x03(\v2#.vexdb.SearchResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x05 \x03(\v2#.vxdb.SearchResponse.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc4\x01\n" +
 	"\rDeleteRequest\x12\x1d\n" +
 	"\n" +
 	"vector_ids\x18\x01 \x03(\tR\tvectorIds\x12Q\n" +
-	"\x0fmetadata_filter\x18\x02 \x03(\v2(.vexdb.DeleteRequest.MetadataFilterEntryR\x0emetadataFilter\x1aA\n" +
+	"\x0fmetadata_filter\x18\x02 \x03(\v2(.vxdb.DeleteRequest.MetadataFilterEntryR\x0emetadataFilter\x1aA\n" +
 	"\x13MetadataFilterEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe7\x01\n" +
@@ -1371,7 +1371,7 @@ const file_vexdb_proto_rawDesc = "" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12#\n" +
 	"\rdeleted_count\x18\x03 \x01(\x03R\fdeletedCount\x12?\n" +
-	"\bmetadata\x18\x04 \x03(\v2#.vexdb.DeleteResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x04 \x03(\v2#.vxdb.DeleteResponse.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf5\x01\n" +
@@ -1381,7 +1381,7 @@ const file_vexdb_proto_rawDesc = "" +
 	"\fvector_count\x18\x03 \x01(\x04R\vvectorCount\x12\x1d\n" +
 	"\n" +
 	"size_bytes\x18\x04 \x01(\x04R\tsizeBytes\x12<\n" +
-	"\bmetadata\x18\x05 \x03(\v2 .vexdb.ClusterInfo.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x05 \x03(\v2 .vxdb.ClusterInfo.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdc\x02\n" +
@@ -1396,16 +1396,16 @@ const file_vexdb_proto_rawDesc = "" +
 	"\fmemory_usage\x18\a \x01(\x04R\vmemoryUsage\x12\x1d\n" +
 	"\n" +
 	"disk_usage\x18\b \x01(\x04R\tdiskUsage\x129\n" +
-	"\bmetadata\x18\t \x03(\v2\x1d.vexdb.NodeInfo.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\t \x03(\v2\x1d.vxdb.NodeInfo.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb9\x02\n" +
 	"\rClusterStatus\x12.\n" +
-	"\bclusters\x18\x01 \x03(\v2\x12.vexdb.ClusterInfoR\bclusters\x12%\n" +
-	"\x05nodes\x18\x02 \x03(\v2\x0f.vexdb.NodeInfoR\x05nodes\x12%\n" +
+	"\bclusters\x18\x01 \x03(\v2\x12.vxdb.ClusterInfoR\bclusters\x12%\n" +
+	"\x05nodes\x18\x02 \x03(\v2\x0f.vxdb.NodeInfoR\x05nodes\x12%\n" +
 	"\x0etotal_clusters\x18\x03 \x01(\rR\rtotalClusters\x12-\n" +
 	"\x12replication_factor\x18\x04 \x01(\rR\x11replicationFactor\x12>\n" +
-	"\bmetadata\x18\x05 \x03(\v2\".vexdb.ClusterStatus.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x05 \x03(\v2\".vxdb.ClusterStatus.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"0\n" +
@@ -1415,7 +1415,7 @@ const file_vexdb_proto_rawDesc = "" +
 	"\ahealthy\x18\x01 \x01(\bR\ahealthy\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12A\n" +
-	"\adetails\x18\x04 \x03(\v2'.vexdb.HealthCheckResponse.DetailsEntryR\adetails\x128\n" +
+	"\adetails\x18\x04 \x03(\v2'.vxdb.HealthCheckResponse.DetailsEntryR\adetails\x128\n" +
 	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x1a:\n" +
 	"\fDetailsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -1429,8 +1429,8 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x0fMetricsResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12=\n" +
-	"\ametrics\x18\x03 \x03(\v2#.vexdb.MetricsResponse.MetricsEntryR\ametrics\x12@\n" +
-	"\bmetadata\x18\x04 \x03(\v2$.vexdb.MetricsResponse.MetadataEntryR\bmetadata\x128\n" +
+	"\ametrics\x18\x03 \x03(\v2#.vxdb.MetricsResponse.MetricsEntryR\ametrics\x12@\n" +
+	"\bmetadata\x18\x04 \x03(\v2$.vxdb.MetricsResponse.MetadataEntryR\bmetadata\x128\n" +
 	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x1a:\n" +
 	"\fMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -1439,7 +1439,7 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd8\x01\n" +
 	"\x13ConfigUpdateRequest\x12T\n" +
-	"\x0econfig_updates\x18\x01 \x03(\v2-.vexdb.ConfigUpdateRequest.ConfigUpdatesEntryR\rconfigUpdates\x12)\n" +
+	"\x0econfig_updates\x18\x01 \x03(\v2-.vxdb.ConfigUpdateRequest.ConfigUpdatesEntryR\rconfigUpdates\x12)\n" +
 	"\x10restart_required\x18\x02 \x01(\bR\x0frestartRequired\x1a@\n" +
 	"\x12ConfigUpdatesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -1447,8 +1447,8 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x14ConfigUpdateResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12X\n" +
-	"\x0fapplied_updates\x18\x03 \x03(\v2/.vexdb.ConfigUpdateResponse.AppliedUpdatesEntryR\x0eappliedUpdates\x12U\n" +
-	"\x0efailed_updates\x18\x04 \x03(\v2..vexdb.ConfigUpdateResponse.FailedUpdatesEntryR\rfailedUpdates\x1aA\n" +
+	"\x0fapplied_updates\x18\x03 \x03(\v2/.vxdb.ConfigUpdateResponse.AppliedUpdatesEntryR\x0eappliedUpdates\x12U\n" +
+	"\x0efailed_updates\x18\x04 \x03(\v2..vxdb.ConfigUpdateResponse.FailedUpdatesEntryR\rfailedUpdates\x1aA\n" +
 	"\x13AppliedUpdatesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
@@ -1456,228 +1456,228 @@ const file_vexdb_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012\x9c\x06\n" +
 	"\x0eStorageService\x12;\n" +
-	"\fInsertVector\x12\x14.vexdb.InsertRequest\x1a\x15.vexdb.InsertResponse\x12E\n" +
-	"\x12InsertVectorStream\x12\x14.vexdb.InsertRequest\x1a\x15.vexdb.InsertResponse(\x010\x01\x125\n" +
-	"\x06Search\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse\x12?\n" +
-	"\fSearchStream\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse(\x010\x01\x12<\n" +
-	"\rDeleteVectors\x12\x14.vexdb.DeleteRequest\x1a\x15.vexdb.DeleteResponse\x12F\n" +
-	"\x13DeleteVectorsStream\x12\x14.vexdb.DeleteRequest\x1a\x15.vexdb.DeleteResponse(\x010\x01\x128\n" +
-	"\x0eGetClusterInfo\x12\x12.vexdb.ClusterInfo\x1a\x12.vexdb.ClusterInfo\x12@\n" +
-	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vexdb.ClusterStatus\x12D\n" +
-	"\vHealthCheck\x12\x19.vexdb.HealthCheckRequest\x1a\x1a.vexdb.HealthCheckResponse\x12;\n" +
+	"\fInsertVector\x12\x14.vxdb.InsertRequest\x1a\x15.vxdb.InsertResponse\x12E\n" +
+	"\x12InsertVectorStream\x12\x14.vxdb.InsertRequest\x1a\x15.vxdb.InsertResponse(\x010\x01\x125\n" +
+	"\x06Search\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse\x12?\n" +
+	"\fSearchStream\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse(\x010\x01\x12<\n" +
+	"\rDeleteVectors\x12\x14.vxdb.DeleteRequest\x1a\x15.vxdb.DeleteResponse\x12F\n" +
+	"\x13DeleteVectorsStream\x12\x14.vxdb.DeleteRequest\x1a\x15.vxdb.DeleteResponse(\x010\x01\x128\n" +
+	"\x0eGetClusterInfo\x12\x12.vxdb.ClusterInfo\x1a\x12.vxdb.ClusterInfo\x12@\n" +
+	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vxdb.ClusterStatus\x12D\n" +
+	"\vHealthCheck\x12\x19.vxdb.HealthCheckRequest\x1a\x1a.vxdb.HealthCheckResponse\x12;\n" +
 	"\n" +
-	"GetMetrics\x12\x15.vexdb.MetricsRequest\x1a\x16.vexdb.MetricsResponse\x12G\n" +
-	"\fUpdateConfig\x12\x1a.vexdb.ConfigUpdateRequest\x1a\x1b.vexdb.ConfigUpdateResponse\x12@\n" +
-	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vexdb.ConfigUpdateResponse2\x9b\x05\n" +
+	"GetMetrics\x12\x15.vxdb.MetricsRequest\x1a\x16.vxdb.MetricsResponse\x12G\n" +
+	"\fUpdateConfig\x12\x1a.vxdb.ConfigUpdateRequest\x1a\x1b.vxdb.ConfigUpdateResponse\x12@\n" +
+	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vxdb.ConfigUpdateResponse2\x9b\x05\n" +
 	"\rInsertService\x12;\n" +
-	"\fInsertVector\x12\x14.vexdb.InsertRequest\x1a\x15.vexdb.InsertResponse\x12E\n" +
-	"\x12InsertVectorStream\x12\x14.vexdb.InsertRequest\x1a\x15.vexdb.InsertResponse(\x010\x01\x128\n" +
-	"\vInsertBatch\x12\x12.vexdb.VectorBatch\x1a\x15.vexdb.InsertResponse\x12B\n" +
-	"\x11InsertBatchStream\x12\x12.vexdb.VectorBatch\x1a\x15.vexdb.InsertResponse(\x010\x01\x128\n" +
-	"\x13GetClusterForVector\x12\r.vexdb.Vector\x1a\x12.vexdb.ClusterInfo\x12@\n" +
-	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vexdb.ClusterStatus\x12D\n" +
-	"\vHealthCheck\x12\x19.vexdb.HealthCheckRequest\x1a\x1a.vexdb.HealthCheckResponse\x12;\n" +
+	"\fInsertVector\x12\x14.vxdb.InsertRequest\x1a\x15.vxdb.InsertResponse\x12E\n" +
+	"\x12InsertVectorStream\x12\x14.vxdb.InsertRequest\x1a\x15.vxdb.InsertResponse(\x010\x01\x128\n" +
+	"\vInsertBatch\x12\x12.vxdb.VectorBatch\x1a\x15.vxdb.InsertResponse\x12B\n" +
+	"\x11InsertBatchStream\x12\x12.vxdb.VectorBatch\x1a\x15.vxdb.InsertResponse(\x010\x01\x128\n" +
+	"\x13GetClusterForVector\x12\r.vxdb.Vector\x1a\x12.vxdb.ClusterInfo\x12@\n" +
+	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vxdb.ClusterStatus\x12D\n" +
+	"\vHealthCheck\x12\x19.vxdb.HealthCheckRequest\x1a\x1a.vxdb.HealthCheckResponse\x12;\n" +
 	"\n" +
-	"GetMetrics\x12\x15.vexdb.MetricsRequest\x1a\x16.vexdb.MetricsResponse\x12G\n" +
-	"\fUpdateConfig\x12\x1a.vexdb.ConfigUpdateRequest\x1a\x1b.vexdb.ConfigUpdateResponse\x12@\n" +
-	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vexdb.ConfigUpdateResponse2\xa1\x05\n" +
+	"GetMetrics\x12\x15.vxdb.MetricsRequest\x1a\x16.vxdb.MetricsResponse\x12G\n" +
+	"\fUpdateConfig\x12\x1a.vxdb.ConfigUpdateRequest\x1a\x1b.vxdb.ConfigUpdateResponse\x12@\n" +
+	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vxdb.ConfigUpdateResponse2\xa1\x05\n" +
 	"\rSearchService\x125\n" +
-	"\x06Search\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse\x12?\n" +
-	"\fSearchStream\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse(\x010\x01\x12A\n" +
-	"\x12MultiClusterSearch\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse\x12K\n" +
-	"\x18MultiClusterSearchStream\x12\x14.vexdb.SearchRequest\x1a\x15.vexdb.SearchResponse(\x010\x01\x128\n" +
-	"\x0eGetClusterInfo\x12\x12.vexdb.ClusterInfo\x1a\x12.vexdb.ClusterInfo\x12@\n" +
-	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vexdb.ClusterStatus\x12D\n" +
-	"\vHealthCheck\x12\x19.vexdb.HealthCheckRequest\x1a\x1a.vexdb.HealthCheckResponse\x12;\n" +
+	"\x06Search\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse\x12?\n" +
+	"\fSearchStream\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse(\x010\x01\x12A\n" +
+	"\x12MultiClusterSearch\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse\x12K\n" +
+	"\x18MultiClusterSearchStream\x12\x14.vxdb.SearchRequest\x1a\x15.vxdb.SearchResponse(\x010\x01\x128\n" +
+	"\x0eGetClusterInfo\x12\x12.vxdb.ClusterInfo\x1a\x12.vxdb.ClusterInfo\x12@\n" +
+	"\x10GetClusterStatus\x12\x16.google.protobuf.Empty\x1a\x14.vxdb.ClusterStatus\x12D\n" +
+	"\vHealthCheck\x12\x19.vxdb.HealthCheckRequest\x1a\x1a.vxdb.HealthCheckResponse\x12;\n" +
 	"\n" +
-	"GetMetrics\x12\x15.vexdb.MetricsRequest\x1a\x16.vexdb.MetricsResponse\x12G\n" +
-	"\fUpdateConfig\x12\x1a.vexdb.ConfigUpdateRequest\x1a\x1b.vexdb.ConfigUpdateResponse\x12@\n" +
-	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vexdb.ConfigUpdateResponse2\xa2\x06\n" +
+	"GetMetrics\x12\x15.vxdb.MetricsRequest\x1a\x16.vxdb.MetricsResponse\x12G\n" +
+	"\fUpdateConfig\x12\x1a.vxdb.ConfigUpdateRequest\x1a\x1b.vxdb.ConfigUpdateResponse\x12@\n" +
+	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vxdb.ConfigUpdateResponse2\xa2\x06\n" +
 	"\fAdminService\x12+\n" +
-	"\aAddNode\x12\x0f.vexdb.NodeInfo\x1a\x0f.vexdb.NodeInfo\x125\n" +
+	"\aAddNode\x12\x0f.vxdb.NodeInfo\x1a\x0f.vxdb.NodeInfo\x125\n" +
 	"\n" +
-	"RemoveNode\x12\x0f.vexdb.NodeInfo\x1a\x16.google.protobuf.Empty\x12.\n" +
+	"RemoveNode\x12\x0f.vxdb.NodeInfo\x1a\x16.google.protobuf.Empty\x12.\n" +
 	"\n" +
-	"UpdateNode\x12\x0f.vexdb.NodeInfo\x1a\x0f.vexdb.NodeInfo\x127\n" +
-	"\rCreateCluster\x12\x12.vexdb.ClusterInfo\x1a\x12.vexdb.ClusterInfo\x12;\n" +
-	"\rDeleteCluster\x12\x12.vexdb.ClusterInfo\x1a\x16.google.protobuf.Empty\x127\n" +
-	"\rUpdateCluster\x12\x12.vexdb.ClusterInfo\x1a\x12.vexdb.ClusterInfo\x12>\n" +
+	"UpdateNode\x12\x0f.vxdb.NodeInfo\x1a\x0f.vxdb.NodeInfo\x127\n" +
+	"\rCreateCluster\x12\x12.vxdb.ClusterInfo\x1a\x12.vxdb.ClusterInfo\x12;\n" +
+	"\rDeleteCluster\x12\x12.vxdb.ClusterInfo\x1a\x16.google.protobuf.Empty\x127\n" +
+	"\rUpdateCluster\x12\x12.vxdb.ClusterInfo\x1a\x12.vxdb.ClusterInfo\x12>\n" +
 	"\fBackupSystem\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12?\n" +
 	"\rRestoreSystem\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12@\n" +
 	"\x0eCompactStorage\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12D\n" +
-	"\vHealthCheck\x12\x19.vexdb.HealthCheckRequest\x1a\x1a.vexdb.HealthCheckResponse\x12;\n" +
+	"\vHealthCheck\x12\x19.vxdb.HealthCheckRequest\x1a\x1a.vxdb.HealthCheckResponse\x12;\n" +
 	"\n" +
-	"GetMetrics\x12\x15.vexdb.MetricsRequest\x1a\x16.vexdb.MetricsResponse\x12G\n" +
-	"\fUpdateConfig\x12\x1a.vexdb.ConfigUpdateRequest\x1a\x1b.vexdb.ConfigUpdateResponse\x12@\n" +
-	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vexdb.ConfigUpdateResponseB\x1eZ\x1cgithub.com/vexdb/vexdb/protob\x06proto3"
+	"GetMetrics\x12\x15.vxdb.MetricsRequest\x1a\x16.vxdb.MetricsResponse\x12G\n" +
+	"\fUpdateConfig\x12\x1a.vxdb.ConfigUpdateRequest\x1a\x1b.vxdb.ConfigUpdateResponse\x12@\n" +
+	"\tGetConfig\x12\x16.google.protobuf.Empty\x1a\x1b.vxdb.ConfigUpdateResponseB\x1eZ\x1cgithub.com/vxdb/vxdb/protob\x06proto3"
 
 var (
-	file_vexdb_proto_rawDescOnce sync.Once
-	file_vexdb_proto_rawDescData []byte
+	file_vxdb_proto_rawDescOnce sync.Once
+	file_vxdb_proto_rawDescData []byte
 )
 
-func file_vexdb_proto_rawDescGZIP() []byte {
-	file_vexdb_proto_rawDescOnce.Do(func() {
-		file_vexdb_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_vexdb_proto_rawDesc), len(file_vexdb_proto_rawDesc)))
+func file_vxdb_proto_rawDescGZIP() []byte {
+	file_vxdb_proto_rawDescOnce.Do(func() {
+		file_vxdb_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_vxdb_proto_rawDesc), len(file_vxdb_proto_rawDesc)))
 	})
-	return file_vexdb_proto_rawDescData
+	return file_vxdb_proto_rawDescData
 }
 
-var file_vexdb_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
-var file_vexdb_proto_goTypes = []any{
-	(*Vector)(nil),                // 0: vexdb.Vector
-	(*VectorBatch)(nil),           // 1: vexdb.VectorBatch
-	(*InsertRequest)(nil),         // 2: vexdb.InsertRequest
-	(*InsertResponse)(nil),        // 3: vexdb.InsertResponse
-	(*SearchRequest)(nil),         // 4: vexdb.SearchRequest
-	(*SearchResult)(nil),          // 5: vexdb.SearchResult
-	(*SearchResponse)(nil),        // 6: vexdb.SearchResponse
-	(*DeleteRequest)(nil),         // 7: vexdb.DeleteRequest
-	(*DeleteResponse)(nil),        // 8: vexdb.DeleteResponse
-	(*ClusterInfo)(nil),           // 9: vexdb.ClusterInfo
-	(*NodeInfo)(nil),              // 10: vexdb.NodeInfo
-	(*ClusterStatus)(nil),         // 11: vexdb.ClusterStatus
-	(*HealthCheckRequest)(nil),    // 12: vexdb.HealthCheckRequest
-	(*HealthCheckResponse)(nil),   // 13: vexdb.HealthCheckResponse
-	(*MetricsRequest)(nil),        // 14: vexdb.MetricsRequest
-	(*MetricsResponse)(nil),       // 15: vexdb.MetricsResponse
-	(*ConfigUpdateRequest)(nil),   // 16: vexdb.ConfigUpdateRequest
-	(*ConfigUpdateResponse)(nil),  // 17: vexdb.ConfigUpdateResponse
-	nil,                           // 18: vexdb.Vector.MetadataEntry
-	nil,                           // 19: vexdb.InsertResponse.MetadataEntry
-	nil,                           // 20: vexdb.SearchRequest.MetadataFilterEntry
-	nil,                           // 21: vexdb.SearchResponse.MetadataEntry
-	nil,                           // 22: vexdb.DeleteRequest.MetadataFilterEntry
-	nil,                           // 23: vexdb.DeleteResponse.MetadataEntry
-	nil,                           // 24: vexdb.ClusterInfo.MetadataEntry
-	nil,                           // 25: vexdb.NodeInfo.MetadataEntry
-	nil,                           // 26: vexdb.ClusterStatus.MetadataEntry
-	nil,                           // 27: vexdb.HealthCheckResponse.DetailsEntry
-	nil,                           // 28: vexdb.MetricsResponse.MetricsEntry
-	nil,                           // 29: vexdb.MetricsResponse.MetadataEntry
-	nil,                           // 30: vexdb.ConfigUpdateRequest.ConfigUpdatesEntry
-	nil,                           // 31: vexdb.ConfigUpdateResponse.AppliedUpdatesEntry
-	nil,                           // 32: vexdb.ConfigUpdateResponse.FailedUpdatesEntry
+var file_vxdb_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_vxdb_proto_goTypes = []any{
+	(*Vector)(nil),                // 0: vxdb.Vector
+	(*VectorBatch)(nil),           // 1: vxdb.VectorBatch
+	(*InsertRequest)(nil),         // 2: vxdb.InsertRequest
+	(*InsertResponse)(nil),        // 3: vxdb.InsertResponse
+	(*SearchRequest)(nil),         // 4: vxdb.SearchRequest
+	(*SearchResult)(nil),          // 5: vxdb.SearchResult
+	(*SearchResponse)(nil),        // 6: vxdb.SearchResponse
+	(*DeleteRequest)(nil),         // 7: vxdb.DeleteRequest
+	(*DeleteResponse)(nil),        // 8: vxdb.DeleteResponse
+	(*ClusterInfo)(nil),           // 9: vxdb.ClusterInfo
+	(*NodeInfo)(nil),              // 10: vxdb.NodeInfo
+	(*ClusterStatus)(nil),         // 11: vxdb.ClusterStatus
+	(*HealthCheckRequest)(nil),    // 12: vxdb.HealthCheckRequest
+	(*HealthCheckResponse)(nil),   // 13: vxdb.HealthCheckResponse
+	(*MetricsRequest)(nil),        // 14: vxdb.MetricsRequest
+	(*MetricsResponse)(nil),       // 15: vxdb.MetricsResponse
+	(*ConfigUpdateRequest)(nil),   // 16: vxdb.ConfigUpdateRequest
+	(*ConfigUpdateResponse)(nil),  // 17: vxdb.ConfigUpdateResponse
+	nil,                           // 18: vxdb.Vector.MetadataEntry
+	nil,                           // 19: vxdb.InsertResponse.MetadataEntry
+	nil,                           // 20: vxdb.SearchRequest.MetadataFilterEntry
+	nil,                           // 21: vxdb.SearchResponse.MetadataEntry
+	nil,                           // 22: vxdb.DeleteRequest.MetadataFilterEntry
+	nil,                           // 23: vxdb.DeleteResponse.MetadataEntry
+	nil,                           // 24: vxdb.ClusterInfo.MetadataEntry
+	nil,                           // 25: vxdb.NodeInfo.MetadataEntry
+	nil,                           // 26: vxdb.ClusterStatus.MetadataEntry
+	nil,                           // 27: vxdb.HealthCheckResponse.DetailsEntry
+	nil,                           // 28: vxdb.MetricsResponse.MetricsEntry
+	nil,                           // 29: vxdb.MetricsResponse.MetadataEntry
+	nil,                           // 30: vxdb.ConfigUpdateRequest.ConfigUpdatesEntry
+	nil,                           // 31: vxdb.ConfigUpdateResponse.AppliedUpdatesEntry
+	nil,                           // 32: vxdb.ConfigUpdateResponse.FailedUpdatesEntry
 	(*timestamppb.Timestamp)(nil), // 33: google.protobuf.Timestamp
 	(*emptypb.Empty)(nil),         // 34: google.protobuf.Empty
 }
-var file_vexdb_proto_depIdxs = []int32{
-	18, // 0: vexdb.Vector.metadata:type_name -> vexdb.Vector.MetadataEntry
-	33, // 1: vexdb.Vector.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 2: vexdb.VectorBatch.vectors:type_name -> vexdb.Vector
-	0,  // 3: vexdb.InsertRequest.vector:type_name -> vexdb.Vector
-	1,  // 4: vexdb.InsertRequest.batch:type_name -> vexdb.VectorBatch
-	19, // 5: vexdb.InsertResponse.metadata:type_name -> vexdb.InsertResponse.MetadataEntry
-	0,  // 6: vexdb.SearchRequest.query_vector:type_name -> vexdb.Vector
-	20, // 7: vexdb.SearchRequest.metadata_filter:type_name -> vexdb.SearchRequest.MetadataFilterEntry
-	0,  // 8: vexdb.SearchResult.vector:type_name -> vexdb.Vector
-	5,  // 9: vexdb.SearchResponse.results:type_name -> vexdb.SearchResult
-	21, // 10: vexdb.SearchResponse.metadata:type_name -> vexdb.SearchResponse.MetadataEntry
-	22, // 11: vexdb.DeleteRequest.metadata_filter:type_name -> vexdb.DeleteRequest.MetadataFilterEntry
-	23, // 12: vexdb.DeleteResponse.metadata:type_name -> vexdb.DeleteResponse.MetadataEntry
-	24, // 13: vexdb.ClusterInfo.metadata:type_name -> vexdb.ClusterInfo.MetadataEntry
-	25, // 14: vexdb.NodeInfo.metadata:type_name -> vexdb.NodeInfo.MetadataEntry
-	9,  // 15: vexdb.ClusterStatus.clusters:type_name -> vexdb.ClusterInfo
-	10, // 16: vexdb.ClusterStatus.nodes:type_name -> vexdb.NodeInfo
-	26, // 17: vexdb.ClusterStatus.metadata:type_name -> vexdb.ClusterStatus.MetadataEntry
-	27, // 18: vexdb.HealthCheckResponse.details:type_name -> vexdb.HealthCheckResponse.DetailsEntry
-	33, // 19: vexdb.HealthCheckResponse.timestamp:type_name -> google.protobuf.Timestamp
-	28, // 20: vexdb.MetricsResponse.metrics:type_name -> vexdb.MetricsResponse.MetricsEntry
-	29, // 21: vexdb.MetricsResponse.metadata:type_name -> vexdb.MetricsResponse.MetadataEntry
-	33, // 22: vexdb.MetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
-	30, // 23: vexdb.ConfigUpdateRequest.config_updates:type_name -> vexdb.ConfigUpdateRequest.ConfigUpdatesEntry
-	31, // 24: vexdb.ConfigUpdateResponse.applied_updates:type_name -> vexdb.ConfigUpdateResponse.AppliedUpdatesEntry
-	32, // 25: vexdb.ConfigUpdateResponse.failed_updates:type_name -> vexdb.ConfigUpdateResponse.FailedUpdatesEntry
-	2,  // 26: vexdb.StorageService.InsertVector:input_type -> vexdb.InsertRequest
-	2,  // 27: vexdb.StorageService.InsertVectorStream:input_type -> vexdb.InsertRequest
-	4,  // 28: vexdb.StorageService.Search:input_type -> vexdb.SearchRequest
-	4,  // 29: vexdb.StorageService.SearchStream:input_type -> vexdb.SearchRequest
-	7,  // 30: vexdb.StorageService.DeleteVectors:input_type -> vexdb.DeleteRequest
-	7,  // 31: vexdb.StorageService.DeleteVectorsStream:input_type -> vexdb.DeleteRequest
-	9,  // 32: vexdb.StorageService.GetClusterInfo:input_type -> vexdb.ClusterInfo
-	34, // 33: vexdb.StorageService.GetClusterStatus:input_type -> google.protobuf.Empty
-	12, // 34: vexdb.StorageService.HealthCheck:input_type -> vexdb.HealthCheckRequest
-	14, // 35: vexdb.StorageService.GetMetrics:input_type -> vexdb.MetricsRequest
-	16, // 36: vexdb.StorageService.UpdateConfig:input_type -> vexdb.ConfigUpdateRequest
-	34, // 37: vexdb.StorageService.GetConfig:input_type -> google.protobuf.Empty
-	2,  // 38: vexdb.InsertService.InsertVector:input_type -> vexdb.InsertRequest
-	2,  // 39: vexdb.InsertService.InsertVectorStream:input_type -> vexdb.InsertRequest
-	1,  // 40: vexdb.InsertService.InsertBatch:input_type -> vexdb.VectorBatch
-	1,  // 41: vexdb.InsertService.InsertBatchStream:input_type -> vexdb.VectorBatch
-	0,  // 42: vexdb.InsertService.GetClusterForVector:input_type -> vexdb.Vector
-	34, // 43: vexdb.InsertService.GetClusterStatus:input_type -> google.protobuf.Empty
-	12, // 44: vexdb.InsertService.HealthCheck:input_type -> vexdb.HealthCheckRequest
-	14, // 45: vexdb.InsertService.GetMetrics:input_type -> vexdb.MetricsRequest
-	16, // 46: vexdb.InsertService.UpdateConfig:input_type -> vexdb.ConfigUpdateRequest
-	34, // 47: vexdb.InsertService.GetConfig:input_type -> google.protobuf.Empty
-	4,  // 48: vexdb.SearchService.Search:input_type -> vexdb.SearchRequest
-	4,  // 49: vexdb.SearchService.SearchStream:input_type -> vexdb.SearchRequest
-	4,  // 50: vexdb.SearchService.MultiClusterSearch:input_type -> vexdb.SearchRequest
-	4,  // 51: vexdb.SearchService.MultiClusterSearchStream:input_type -> vexdb.SearchRequest
-	9,  // 52: vexdb.SearchService.GetClusterInfo:input_type -> vexdb.ClusterInfo
-	34, // 53: vexdb.SearchService.GetClusterStatus:input_type -> google.protobuf.Empty
-	12, // 54: vexdb.SearchService.HealthCheck:input_type -> vexdb.HealthCheckRequest
-	14, // 55: vexdb.SearchService.GetMetrics:input_type -> vexdb.MetricsRequest
-	16, // 56: vexdb.SearchService.UpdateConfig:input_type -> vexdb.ConfigUpdateRequest
-	34, // 57: vexdb.SearchService.GetConfig:input_type -> google.protobuf.Empty
-	10, // 58: vexdb.AdminService.AddNode:input_type -> vexdb.NodeInfo
-	10, // 59: vexdb.AdminService.RemoveNode:input_type -> vexdb.NodeInfo
-	10, // 60: vexdb.AdminService.UpdateNode:input_type -> vexdb.NodeInfo
-	9,  // 61: vexdb.AdminService.CreateCluster:input_type -> vexdb.ClusterInfo
-	9,  // 62: vexdb.AdminService.DeleteCluster:input_type -> vexdb.ClusterInfo
-	9,  // 63: vexdb.AdminService.UpdateCluster:input_type -> vexdb.ClusterInfo
-	34, // 64: vexdb.AdminService.BackupSystem:input_type -> google.protobuf.Empty
-	34, // 65: vexdb.AdminService.RestoreSystem:input_type -> google.protobuf.Empty
-	34, // 66: vexdb.AdminService.CompactStorage:input_type -> google.protobuf.Empty
-	12, // 67: vexdb.AdminService.HealthCheck:input_type -> vexdb.HealthCheckRequest
-	14, // 68: vexdb.AdminService.GetMetrics:input_type -> vexdb.MetricsRequest
-	16, // 69: vexdb.AdminService.UpdateConfig:input_type -> vexdb.ConfigUpdateRequest
-	34, // 70: vexdb.AdminService.GetConfig:input_type -> google.protobuf.Empty
-	3,  // 71: vexdb.StorageService.InsertVector:output_type -> vexdb.InsertResponse
-	3,  // 72: vexdb.StorageService.InsertVectorStream:output_type -> vexdb.InsertResponse
-	6,  // 73: vexdb.StorageService.Search:output_type -> vexdb.SearchResponse
-	6,  // 74: vexdb.StorageService.SearchStream:output_type -> vexdb.SearchResponse
-	8,  // 75: vexdb.StorageService.DeleteVectors:output_type -> vexdb.DeleteResponse
-	8,  // 76: vexdb.StorageService.DeleteVectorsStream:output_type -> vexdb.DeleteResponse
-	9,  // 77: vexdb.StorageService.GetClusterInfo:output_type -> vexdb.ClusterInfo
-	11, // 78: vexdb.StorageService.GetClusterStatus:output_type -> vexdb.ClusterStatus
-	13, // 79: vexdb.StorageService.HealthCheck:output_type -> vexdb.HealthCheckResponse
-	15, // 80: vexdb.StorageService.GetMetrics:output_type -> vexdb.MetricsResponse
-	17, // 81: vexdb.StorageService.UpdateConfig:output_type -> vexdb.ConfigUpdateResponse
-	17, // 82: vexdb.StorageService.GetConfig:output_type -> vexdb.ConfigUpdateResponse
-	3,  // 83: vexdb.InsertService.InsertVector:output_type -> vexdb.InsertResponse
-	3,  // 84: vexdb.InsertService.InsertVectorStream:output_type -> vexdb.InsertResponse
-	3,  // 85: vexdb.InsertService.InsertBatch:output_type -> vexdb.InsertResponse
-	3,  // 86: vexdb.InsertService.InsertBatchStream:output_type -> vexdb.InsertResponse
-	9,  // 87: vexdb.InsertService.GetClusterForVector:output_type -> vexdb.ClusterInfo
-	11, // 88: vexdb.InsertService.GetClusterStatus:output_type -> vexdb.ClusterStatus
-	13, // 89: vexdb.InsertService.HealthCheck:output_type -> vexdb.HealthCheckResponse
-	15, // 90: vexdb.InsertService.GetMetrics:output_type -> vexdb.MetricsResponse
-	17, // 91: vexdb.InsertService.UpdateConfig:output_type -> vexdb.ConfigUpdateResponse
-	17, // 92: vexdb.InsertService.GetConfig:output_type -> vexdb.ConfigUpdateResponse
-	6,  // 93: vexdb.SearchService.Search:output_type -> vexdb.SearchResponse
-	6,  // 94: vexdb.SearchService.SearchStream:output_type -> vexdb.SearchResponse
-	6,  // 95: vexdb.SearchService.MultiClusterSearch:output_type -> vexdb.SearchResponse
-	6,  // 96: vexdb.SearchService.MultiClusterSearchStream:output_type -> vexdb.SearchResponse
-	9,  // 97: vexdb.SearchService.GetClusterInfo:output_type -> vexdb.ClusterInfo
-	11, // 98: vexdb.SearchService.GetClusterStatus:output_type -> vexdb.ClusterStatus
-	13, // 99: vexdb.SearchService.HealthCheck:output_type -> vexdb.HealthCheckResponse
-	15, // 100: vexdb.SearchService.GetMetrics:output_type -> vexdb.MetricsResponse
-	17, // 101: vexdb.SearchService.UpdateConfig:output_type -> vexdb.ConfigUpdateResponse
-	17, // 102: vexdb.SearchService.GetConfig:output_type -> vexdb.ConfigUpdateResponse
-	10, // 103: vexdb.AdminService.AddNode:output_type -> vexdb.NodeInfo
-	34, // 104: vexdb.AdminService.RemoveNode:output_type -> google.protobuf.Empty
-	10, // 105: vexdb.AdminService.UpdateNode:output_type -> vexdb.NodeInfo
-	9,  // 106: vexdb.AdminService.CreateCluster:output_type -> vexdb.ClusterInfo
-	34, // 107: vexdb.AdminService.DeleteCluster:output_type -> google.protobuf.Empty
-	9,  // 108: vexdb.AdminService.UpdateCluster:output_type -> vexdb.ClusterInfo
-	34, // 109: vexdb.AdminService.BackupSystem:output_type -> google.protobuf.Empty
-	34, // 110: vexdb.AdminService.RestoreSystem:output_type -> google.protobuf.Empty
-	34, // 111: vexdb.AdminService.CompactStorage:output_type -> google.protobuf.Empty
-	13, // 112: vexdb.AdminService.HealthCheck:output_type -> vexdb.HealthCheckResponse
-	15, // 113: vexdb.AdminService.GetMetrics:output_type -> vexdb.MetricsResponse
-	17, // 114: vexdb.AdminService.UpdateConfig:output_type -> vexdb.ConfigUpdateResponse
-	17, // 115: vexdb.AdminService.GetConfig:output_type -> vexdb.ConfigUpdateResponse
+var file_vxdb_proto_depIdxs = []int32{
+	18, // 0: vxdb.Vector.metadata:type_name -> vxdb.Vector.MetadataEntry
+	33, // 1: vxdb.Vector.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 2: vxdb.VectorBatch.vectors:type_name -> vxdb.Vector
+	0,  // 3: vxdb.InsertRequest.vector:type_name -> vxdb.Vector
+	1,  // 4: vxdb.InsertRequest.batch:type_name -> vxdb.VectorBatch
+	19, // 5: vxdb.InsertResponse.metadata:type_name -> vxdb.InsertResponse.MetadataEntry
+	0,  // 6: vxdb.SearchRequest.query_vector:type_name -> vxdb.Vector
+	20, // 7: vxdb.SearchRequest.metadata_filter:type_name -> vxdb.SearchRequest.MetadataFilterEntry
+	0,  // 8: vxdb.SearchResult.vector:type_name -> vxdb.Vector
+	5,  // 9: vxdb.SearchResponse.results:type_name -> vxdb.SearchResult
+	21, // 10: vxdb.SearchResponse.metadata:type_name -> vxdb.SearchResponse.MetadataEntry
+	22, // 11: vxdb.DeleteRequest.metadata_filter:type_name -> vxdb.DeleteRequest.MetadataFilterEntry
+	23, // 12: vxdb.DeleteResponse.metadata:type_name -> vxdb.DeleteResponse.MetadataEntry
+	24, // 13: vxdb.ClusterInfo.metadata:type_name -> vxdb.ClusterInfo.MetadataEntry
+	25, // 14: vxdb.NodeInfo.metadata:type_name -> vxdb.NodeInfo.MetadataEntry
+	9,  // 15: vxdb.ClusterStatus.clusters:type_name -> vxdb.ClusterInfo
+	10, // 16: vxdb.ClusterStatus.nodes:type_name -> vxdb.NodeInfo
+	26, // 17: vxdb.ClusterStatus.metadata:type_name -> vxdb.ClusterStatus.MetadataEntry
+	27, // 18: vxdb.HealthCheckResponse.details:type_name -> vxdb.HealthCheckResponse.DetailsEntry
+	33, // 19: vxdb.HealthCheckResponse.timestamp:type_name -> google.protobuf.Timestamp
+	28, // 20: vxdb.MetricsResponse.metrics:type_name -> vxdb.MetricsResponse.MetricsEntry
+	29, // 21: vxdb.MetricsResponse.metadata:type_name -> vxdb.MetricsResponse.MetadataEntry
+	33, // 22: vxdb.MetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
+	30, // 23: vxdb.ConfigUpdateRequest.config_updates:type_name -> vxdb.ConfigUpdateRequest.ConfigUpdatesEntry
+	31, // 24: vxdb.ConfigUpdateResponse.applied_updates:type_name -> vxdb.ConfigUpdateResponse.AppliedUpdatesEntry
+	32, // 25: vxdb.ConfigUpdateResponse.failed_updates:type_name -> vxdb.ConfigUpdateResponse.FailedUpdatesEntry
+	2,  // 26: vxdb.StorageService.InsertVector:input_type -> vxdb.InsertRequest
+	2,  // 27: vxdb.StorageService.InsertVectorStream:input_type -> vxdb.InsertRequest
+	4,  // 28: vxdb.StorageService.Search:input_type -> vxdb.SearchRequest
+	4,  // 29: vxdb.StorageService.SearchStream:input_type -> vxdb.SearchRequest
+	7,  // 30: vxdb.StorageService.DeleteVectors:input_type -> vxdb.DeleteRequest
+	7,  // 31: vxdb.StorageService.DeleteVectorsStream:input_type -> vxdb.DeleteRequest
+	9,  // 32: vxdb.StorageService.GetClusterInfo:input_type -> vxdb.ClusterInfo
+	34, // 33: vxdb.StorageService.GetClusterStatus:input_type -> google.protobuf.Empty
+	12, // 34: vxdb.StorageService.HealthCheck:input_type -> vxdb.HealthCheckRequest
+	14, // 35: vxdb.StorageService.GetMetrics:input_type -> vxdb.MetricsRequest
+	16, // 36: vxdb.StorageService.UpdateConfig:input_type -> vxdb.ConfigUpdateRequest
+	34, // 37: vxdb.StorageService.GetConfig:input_type -> google.protobuf.Empty
+	2,  // 38: vxdb.InsertService.InsertVector:input_type -> vxdb.InsertRequest
+	2,  // 39: vxdb.InsertService.InsertVectorStream:input_type -> vxdb.InsertRequest
+	1,  // 40: vxdb.InsertService.InsertBatch:input_type -> vxdb.VectorBatch
+	1,  // 41: vxdb.InsertService.InsertBatchStream:input_type -> vxdb.VectorBatch
+	0,  // 42: vxdb.InsertService.GetClusterForVector:input_type -> vxdb.Vector
+	34, // 43: vxdb.InsertService.GetClusterStatus:input_type -> google.protobuf.Empty
+	12, // 44: vxdb.InsertService.HealthCheck:input_type -> vxdb.HealthCheckRequest
+	14, // 45: vxdb.InsertService.GetMetrics:input_type -> vxdb.MetricsRequest
+	16, // 46: vxdb.InsertService.UpdateConfig:input_type -> vxdb.ConfigUpdateRequest
+	34, // 47: vxdb.InsertService.GetConfig:input_type -> google.protobuf.Empty
+	4,  // 48: vxdb.SearchService.Search:input_type -> vxdb.SearchRequest
+	4,  // 49: vxdb.SearchService.SearchStream:input_type -> vxdb.SearchRequest
+	4,  // 50: vxdb.SearchService.MultiClusterSearch:input_type -> vxdb.SearchRequest
+	4,  // 51: vxdb.SearchService.MultiClusterSearchStream:input_type -> vxdb.SearchRequest
+	9,  // 52: vxdb.SearchService.GetClusterInfo:input_type -> vxdb.ClusterInfo
+	34, // 53: vxdb.SearchService.GetClusterStatus:input_type -> google.protobuf.Empty
+	12, // 54: vxdb.SearchService.HealthCheck:input_type -> vxdb.HealthCheckRequest
+	14, // 55: vxdb.SearchService.GetMetrics:input_type -> vxdb.MetricsRequest
+	16, // 56: vxdb.SearchService.UpdateConfig:input_type -> vxdb.ConfigUpdateRequest
+	34, // 57: vxdb.SearchService.GetConfig:input_type -> google.protobuf.Empty
+	10, // 58: vxdb.AdminService.AddNode:input_type -> vxdb.NodeInfo
+	10, // 59: vxdb.AdminService.RemoveNode:input_type -> vxdb.NodeInfo
+	10, // 60: vxdb.AdminService.UpdateNode:input_type -> vxdb.NodeInfo
+	9,  // 61: vxdb.AdminService.CreateCluster:input_type -> vxdb.ClusterInfo
+	9,  // 62: vxdb.AdminService.DeleteCluster:input_type -> vxdb.ClusterInfo
+	9,  // 63: vxdb.AdminService.UpdateCluster:input_type -> vxdb.ClusterInfo
+	34, // 64: vxdb.AdminService.BackupSystem:input_type -> google.protobuf.Empty
+	34, // 65: vxdb.AdminService.RestoreSystem:input_type -> google.protobuf.Empty
+	34, // 66: vxdb.AdminService.CompactStorage:input_type -> google.protobuf.Empty
+	12, // 67: vxdb.AdminService.HealthCheck:input_type -> vxdb.HealthCheckRequest
+	14, // 68: vxdb.AdminService.GetMetrics:input_type -> vxdb.MetricsRequest
+	16, // 69: vxdb.AdminService.UpdateConfig:input_type -> vxdb.ConfigUpdateRequest
+	34, // 70: vxdb.AdminService.GetConfig:input_type -> google.protobuf.Empty
+	3,  // 71: vxdb.StorageService.InsertVector:output_type -> vxdb.InsertResponse
+	3,  // 72: vxdb.StorageService.InsertVectorStream:output_type -> vxdb.InsertResponse
+	6,  // 73: vxdb.StorageService.Search:output_type -> vxdb.SearchResponse
+	6,  // 74: vxdb.StorageService.SearchStream:output_type -> vxdb.SearchResponse
+	8,  // 75: vxdb.StorageService.DeleteVectors:output_type -> vxdb.DeleteResponse
+	8,  // 76: vxdb.StorageService.DeleteVectorsStream:output_type -> vxdb.DeleteResponse
+	9,  // 77: vxdb.StorageService.GetClusterInfo:output_type -> vxdb.ClusterInfo
+	11, // 78: vxdb.StorageService.GetClusterStatus:output_type -> vxdb.ClusterStatus
+	13, // 79: vxdb.StorageService.HealthCheck:output_type -> vxdb.HealthCheckResponse
+	15, // 80: vxdb.StorageService.GetMetrics:output_type -> vxdb.MetricsResponse
+	17, // 81: vxdb.StorageService.UpdateConfig:output_type -> vxdb.ConfigUpdateResponse
+	17, // 82: vxdb.StorageService.GetConfig:output_type -> vxdb.ConfigUpdateResponse
+	3,  // 83: vxdb.InsertService.InsertVector:output_type -> vxdb.InsertResponse
+	3,  // 84: vxdb.InsertService.InsertVectorStream:output_type -> vxdb.InsertResponse
+	3,  // 85: vxdb.InsertService.InsertBatch:output_type -> vxdb.InsertResponse
+	3,  // 86: vxdb.InsertService.InsertBatchStream:output_type -> vxdb.InsertResponse
+	9,  // 87: vxdb.InsertService.GetClusterForVector:output_type -> vxdb.ClusterInfo
+	11, // 88: vxdb.InsertService.GetClusterStatus:output_type -> vxdb.ClusterStatus
+	13, // 89: vxdb.InsertService.HealthCheck:output_type -> vxdb.HealthCheckResponse
+	15, // 90: vxdb.InsertService.GetMetrics:output_type -> vxdb.MetricsResponse
+	17, // 91: vxdb.InsertService.UpdateConfig:output_type -> vxdb.ConfigUpdateResponse
+	17, // 92: vxdb.InsertService.GetConfig:output_type -> vxdb.ConfigUpdateResponse
+	6,  // 93: vxdb.SearchService.Search:output_type -> vxdb.SearchResponse
+	6,  // 94: vxdb.SearchService.SearchStream:output_type -> vxdb.SearchResponse
+	6,  // 95: vxdb.SearchService.MultiClusterSearch:output_type -> vxdb.SearchResponse
+	6,  // 96: vxdb.SearchService.MultiClusterSearchStream:output_type -> vxdb.SearchResponse
+	9,  // 97: vxdb.SearchService.GetClusterInfo:output_type -> vxdb.ClusterInfo
+	11, // 98: vxdb.SearchService.GetClusterStatus:output_type -> vxdb.ClusterStatus
+	13, // 99: vxdb.SearchService.HealthCheck:output_type -> vxdb.HealthCheckResponse
+	15, // 100: vxdb.SearchService.GetMetrics:output_type -> vxdb.MetricsResponse
+	17, // 101: vxdb.SearchService.UpdateConfig:output_type -> vxdb.ConfigUpdateResponse
+	17, // 102: vxdb.SearchService.GetConfig:output_type -> vxdb.ConfigUpdateResponse
+	10, // 103: vxdb.AdminService.AddNode:output_type -> vxdb.NodeInfo
+	34, // 104: vxdb.AdminService.RemoveNode:output_type -> google.protobuf.Empty
+	10, // 105: vxdb.AdminService.UpdateNode:output_type -> vxdb.NodeInfo
+	9,  // 106: vxdb.AdminService.CreateCluster:output_type -> vxdb.ClusterInfo
+	34, // 107: vxdb.AdminService.DeleteCluster:output_type -> google.protobuf.Empty
+	9,  // 108: vxdb.AdminService.UpdateCluster:output_type -> vxdb.ClusterInfo
+	34, // 109: vxdb.AdminService.BackupSystem:output_type -> google.protobuf.Empty
+	34, // 110: vxdb.AdminService.RestoreSystem:output_type -> google.protobuf.Empty
+	34, // 111: vxdb.AdminService.CompactStorage:output_type -> google.protobuf.Empty
+	13, // 112: vxdb.AdminService.HealthCheck:output_type -> vxdb.HealthCheckResponse
+	15, // 113: vxdb.AdminService.GetMetrics:output_type -> vxdb.MetricsResponse
+	17, // 114: vxdb.AdminService.UpdateConfig:output_type -> vxdb.ConfigUpdateResponse
+	17, // 115: vxdb.AdminService.GetConfig:output_type -> vxdb.ConfigUpdateResponse
 	71, // [71:116] is the sub-list for method output_type
 	26, // [26:71] is the sub-list for method input_type
 	26, // [26:26] is the sub-list for extension type_name
@@ -1685,12 +1685,12 @@ var file_vexdb_proto_depIdxs = []int32{
 	0,  // [0:26] is the sub-list for field type_name
 }
 
-func init() { file_vexdb_proto_init() }
-func file_vexdb_proto_init() {
-	if File_vexdb_proto != nil {
+func init() { file_vxdb_proto_init() }
+func file_vxdb_proto_init() {
+	if File_vxdb_proto != nil {
 		return
 	}
-	file_vexdb_proto_msgTypes[2].OneofWrappers = []any{
+	file_vxdb_proto_msgTypes[2].OneofWrappers = []any{
 		(*InsertRequest_Vector)(nil),
 		(*InsertRequest_Batch)(nil),
 	}
@@ -1698,17 +1698,17 @@ func file_vexdb_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vexdb_proto_rawDesc), len(file_vexdb_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vxdb_proto_rawDesc), len(file_vxdb_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   4,
 		},
-		GoTypes:           file_vexdb_proto_goTypes,
-		DependencyIndexes: file_vexdb_proto_depIdxs,
-		MessageInfos:      file_vexdb_proto_msgTypes,
+		GoTypes:           file_vxdb_proto_goTypes,
+		DependencyIndexes: file_vxdb_proto_depIdxs,
+		MessageInfos:      file_vxdb_proto_msgTypes,
 	}.Build()
-	File_vexdb_proto = out.File
-	file_vexdb_proto_goTypes = nil
-	file_vexdb_proto_depIdxs = nil
+	File_vxdb_proto = out.File
+	file_vxdb_proto_goTypes = nil
+	file_vxdb_proto_depIdxs = nil
 }

--- a/proto/vxdb.proto
+++ b/proto/vxdb.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-package vexdb;
+package vxdb;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 
-option go_package = "github.com/vexdb/vexdb/proto";
+option go_package = "github.com/vxdb/vxdb/proto";
 
 // Vector represents a vector with metadata
 message Vector {

--- a/proto/vxdb_grpc.pb.go
+++ b/proto/vxdb_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v3.21.12
-// source: vexdb.proto
+// source: vxdb.proto
 
 package proto
 
@@ -20,18 +20,18 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	StorageService_InsertVector_FullMethodName        = "/vexdb.StorageService/InsertVector"
-	StorageService_InsertVectorStream_FullMethodName  = "/vexdb.StorageService/InsertVectorStream"
-	StorageService_Search_FullMethodName              = "/vexdb.StorageService/Search"
-	StorageService_SearchStream_FullMethodName        = "/vexdb.StorageService/SearchStream"
-	StorageService_DeleteVectors_FullMethodName       = "/vexdb.StorageService/DeleteVectors"
-	StorageService_DeleteVectorsStream_FullMethodName = "/vexdb.StorageService/DeleteVectorsStream"
-	StorageService_GetClusterInfo_FullMethodName      = "/vexdb.StorageService/GetClusterInfo"
-	StorageService_GetClusterStatus_FullMethodName    = "/vexdb.StorageService/GetClusterStatus"
-	StorageService_HealthCheck_FullMethodName         = "/vexdb.StorageService/HealthCheck"
-	StorageService_GetMetrics_FullMethodName          = "/vexdb.StorageService/GetMetrics"
-	StorageService_UpdateConfig_FullMethodName        = "/vexdb.StorageService/UpdateConfig"
-	StorageService_GetConfig_FullMethodName           = "/vexdb.StorageService/GetConfig"
+	StorageService_InsertVector_FullMethodName        = "/vxdb.StorageService/InsertVector"
+	StorageService_InsertVectorStream_FullMethodName  = "/vxdb.StorageService/InsertVectorStream"
+	StorageService_Search_FullMethodName              = "/vxdb.StorageService/Search"
+	StorageService_SearchStream_FullMethodName        = "/vxdb.StorageService/SearchStream"
+	StorageService_DeleteVectors_FullMethodName       = "/vxdb.StorageService/DeleteVectors"
+	StorageService_DeleteVectorsStream_FullMethodName = "/vxdb.StorageService/DeleteVectorsStream"
+	StorageService_GetClusterInfo_FullMethodName      = "/vxdb.StorageService/GetClusterInfo"
+	StorageService_GetClusterStatus_FullMethodName    = "/vxdb.StorageService/GetClusterStatus"
+	StorageService_HealthCheck_FullMethodName         = "/vxdb.StorageService/HealthCheck"
+	StorageService_GetMetrics_FullMethodName          = "/vxdb.StorageService/GetMetrics"
+	StorageService_UpdateConfig_FullMethodName        = "/vxdb.StorageService/UpdateConfig"
+	StorageService_GetConfig_FullMethodName           = "/vxdb.StorageService/GetConfig"
 )
 
 // StorageServiceClient is the client API for StorageService service.
@@ -475,7 +475,7 @@ func _StorageService_GetConfig_Handler(srv interface{}, ctx context.Context, dec
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var StorageService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "vexdb.StorageService",
+	ServiceName: "vxdb.StorageService",
 	HandlerType: (*StorageServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -535,20 +535,20 @@ var StorageService_ServiceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: "vexdb.proto",
+	Metadata: "vxdb.proto",
 }
 
 const (
-	InsertService_InsertVector_FullMethodName        = "/vexdb.InsertService/InsertVector"
-	InsertService_InsertVectorStream_FullMethodName  = "/vexdb.InsertService/InsertVectorStream"
-	InsertService_InsertBatch_FullMethodName         = "/vexdb.InsertService/InsertBatch"
-	InsertService_InsertBatchStream_FullMethodName   = "/vexdb.InsertService/InsertBatchStream"
-	InsertService_GetClusterForVector_FullMethodName = "/vexdb.InsertService/GetClusterForVector"
-	InsertService_GetClusterStatus_FullMethodName    = "/vexdb.InsertService/GetClusterStatus"
-	InsertService_HealthCheck_FullMethodName         = "/vexdb.InsertService/HealthCheck"
-	InsertService_GetMetrics_FullMethodName          = "/vexdb.InsertService/GetMetrics"
-	InsertService_UpdateConfig_FullMethodName        = "/vexdb.InsertService/UpdateConfig"
-	InsertService_GetConfig_FullMethodName           = "/vexdb.InsertService/GetConfig"
+	InsertService_InsertVector_FullMethodName        = "/vxdb.InsertService/InsertVector"
+	InsertService_InsertVectorStream_FullMethodName  = "/vxdb.InsertService/InsertVectorStream"
+	InsertService_InsertBatch_FullMethodName         = "/vxdb.InsertService/InsertBatch"
+	InsertService_InsertBatchStream_FullMethodName   = "/vxdb.InsertService/InsertBatchStream"
+	InsertService_GetClusterForVector_FullMethodName = "/vxdb.InsertService/GetClusterForVector"
+	InsertService_GetClusterStatus_FullMethodName    = "/vxdb.InsertService/GetClusterStatus"
+	InsertService_HealthCheck_FullMethodName         = "/vxdb.InsertService/HealthCheck"
+	InsertService_GetMetrics_FullMethodName          = "/vxdb.InsertService/GetMetrics"
+	InsertService_UpdateConfig_FullMethodName        = "/vxdb.InsertService/UpdateConfig"
+	InsertService_GetConfig_FullMethodName           = "/vxdb.InsertService/GetConfig"
 )
 
 // InsertServiceClient is the client API for InsertService service.
@@ -932,7 +932,7 @@ func _InsertService_GetConfig_Handler(srv interface{}, ctx context.Context, dec 
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var InsertService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "vexdb.InsertService",
+	ServiceName: "vxdb.InsertService",
 	HandlerType: (*InsertServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -982,20 +982,20 @@ var InsertService_ServiceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: "vexdb.proto",
+	Metadata: "vxdb.proto",
 }
 
 const (
-	SearchService_Search_FullMethodName                   = "/vexdb.SearchService/Search"
-	SearchService_SearchStream_FullMethodName             = "/vexdb.SearchService/SearchStream"
-	SearchService_MultiClusterSearch_FullMethodName       = "/vexdb.SearchService/MultiClusterSearch"
-	SearchService_MultiClusterSearchStream_FullMethodName = "/vexdb.SearchService/MultiClusterSearchStream"
-	SearchService_GetClusterInfo_FullMethodName           = "/vexdb.SearchService/GetClusterInfo"
-	SearchService_GetClusterStatus_FullMethodName         = "/vexdb.SearchService/GetClusterStatus"
-	SearchService_HealthCheck_FullMethodName              = "/vexdb.SearchService/HealthCheck"
-	SearchService_GetMetrics_FullMethodName               = "/vexdb.SearchService/GetMetrics"
-	SearchService_UpdateConfig_FullMethodName             = "/vexdb.SearchService/UpdateConfig"
-	SearchService_GetConfig_FullMethodName                = "/vexdb.SearchService/GetConfig"
+	SearchService_Search_FullMethodName                   = "/vxdb.SearchService/Search"
+	SearchService_SearchStream_FullMethodName             = "/vxdb.SearchService/SearchStream"
+	SearchService_MultiClusterSearch_FullMethodName       = "/vxdb.SearchService/MultiClusterSearch"
+	SearchService_MultiClusterSearchStream_FullMethodName = "/vxdb.SearchService/MultiClusterSearchStream"
+	SearchService_GetClusterInfo_FullMethodName           = "/vxdb.SearchService/GetClusterInfo"
+	SearchService_GetClusterStatus_FullMethodName         = "/vxdb.SearchService/GetClusterStatus"
+	SearchService_HealthCheck_FullMethodName              = "/vxdb.SearchService/HealthCheck"
+	SearchService_GetMetrics_FullMethodName               = "/vxdb.SearchService/GetMetrics"
+	SearchService_UpdateConfig_FullMethodName             = "/vxdb.SearchService/UpdateConfig"
+	SearchService_GetConfig_FullMethodName                = "/vxdb.SearchService/GetConfig"
 )
 
 // SearchServiceClient is the client API for SearchService service.
@@ -1379,7 +1379,7 @@ func _SearchService_GetConfig_Handler(srv interface{}, ctx context.Context, dec 
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var SearchService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "vexdb.SearchService",
+	ServiceName: "vxdb.SearchService",
 	HandlerType: (*SearchServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -1429,23 +1429,23 @@ var SearchService_ServiceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: "vexdb.proto",
+	Metadata: "vxdb.proto",
 }
 
 const (
-	AdminService_AddNode_FullMethodName        = "/vexdb.AdminService/AddNode"
-	AdminService_RemoveNode_FullMethodName     = "/vexdb.AdminService/RemoveNode"
-	AdminService_UpdateNode_FullMethodName     = "/vexdb.AdminService/UpdateNode"
-	AdminService_CreateCluster_FullMethodName  = "/vexdb.AdminService/CreateCluster"
-	AdminService_DeleteCluster_FullMethodName  = "/vexdb.AdminService/DeleteCluster"
-	AdminService_UpdateCluster_FullMethodName  = "/vexdb.AdminService/UpdateCluster"
-	AdminService_BackupSystem_FullMethodName   = "/vexdb.AdminService/BackupSystem"
-	AdminService_RestoreSystem_FullMethodName  = "/vexdb.AdminService/RestoreSystem"
-	AdminService_CompactStorage_FullMethodName = "/vexdb.AdminService/CompactStorage"
-	AdminService_HealthCheck_FullMethodName    = "/vexdb.AdminService/HealthCheck"
-	AdminService_GetMetrics_FullMethodName     = "/vexdb.AdminService/GetMetrics"
-	AdminService_UpdateConfig_FullMethodName   = "/vexdb.AdminService/UpdateConfig"
-	AdminService_GetConfig_FullMethodName      = "/vexdb.AdminService/GetConfig"
+	AdminService_AddNode_FullMethodName        = "/vxdb.AdminService/AddNode"
+	AdminService_RemoveNode_FullMethodName     = "/vxdb.AdminService/RemoveNode"
+	AdminService_UpdateNode_FullMethodName     = "/vxdb.AdminService/UpdateNode"
+	AdminService_CreateCluster_FullMethodName  = "/vxdb.AdminService/CreateCluster"
+	AdminService_DeleteCluster_FullMethodName  = "/vxdb.AdminService/DeleteCluster"
+	AdminService_UpdateCluster_FullMethodName  = "/vxdb.AdminService/UpdateCluster"
+	AdminService_BackupSystem_FullMethodName   = "/vxdb.AdminService/BackupSystem"
+	AdminService_RestoreSystem_FullMethodName  = "/vxdb.AdminService/RestoreSystem"
+	AdminService_CompactStorage_FullMethodName = "/vxdb.AdminService/CompactStorage"
+	AdminService_HealthCheck_FullMethodName    = "/vxdb.AdminService/HealthCheck"
+	AdminService_GetMetrics_FullMethodName     = "/vxdb.AdminService/GetMetrics"
+	AdminService_UpdateConfig_FullMethodName   = "/vxdb.AdminService/UpdateConfig"
+	AdminService_GetConfig_FullMethodName      = "/vxdb.AdminService/GetConfig"
 )
 
 // AdminServiceClient is the client API for AdminService service.
@@ -1944,7 +1944,7 @@ func _AdminService_GetConfig_Handler(srv interface{}, ctx context.Context, dec f
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var AdminService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "vexdb.AdminService",
+	ServiceName: "vxdb.AdminService",
 	HandlerType: (*AdminServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -2001,5 +2001,5 @@ var AdminService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "vexdb.proto",
+	Metadata: "vxdb.proto",
 }


### PR DESCRIPTION
## Summary
- rename all `vex*` references to `vx*` across the repository
- update Makefile and configs for new command paths
- switch Go module path to `vxdb`

## Testing
- `go build ./cmd/vxinsert/`
- `go build ./cmd/vxstorage/`
- `go build ./cmd/vxsearch/`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c1408422ec8323ab6705121636551d