### PR TITLE
feat: implement modular IVF search index

### DIFF
--- a/internal/protocol/rate/limiter_test.go
+++ b/internal/protocol/rate/limiter_test.go
@@ -1,0 +1,114 @@
+package rate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"vxdb/internal/metrics"
+)
+
+// TestValidateRateLimitConfig ensures configuration validation catches invalid settings.
+func TestValidateRateLimitConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*RateLimitConfig)
+	}{
+		{
+			name:   "non-positive default limit",
+			modify: func(cfg *RateLimitConfig) { cfg.DefaultLimit = 0 },
+		},
+		{
+			name:   "non-positive window",
+			modify: func(cfg *RateLimitConfig) { cfg.DefaultWindow = 0 },
+		},
+		{
+			name: "distributed enabled without redis address",
+			modify: func(cfg *RateLimitConfig) {
+				cfg.EnableDistributed = true
+				cfg.RedisAddress = ""
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultRateLimitConfig()
+			tt.modify(cfg)
+			if err := validateRateLimitConfig(cfg); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+// newTestLimiter creates a RateLimiter with default config and disables optional features
+// that may interfere with deterministic testing.
+func newTestLimiter(t *testing.T) *RateLimiter {
+	t.Helper()
+	m, _ := metrics.NewMetrics(nil)
+	sm := metrics.NewServiceMetrics(m, "test")
+	logger := zap.NewNop()
+
+	limiter, err := NewRateLimiter(nil, *logger, sm)
+	if err != nil {
+		t.Fatalf("NewRateLimiter returned error: %v", err)
+	}
+
+	// Disable features to make behaviour deterministic for tests
+	limiter.config.EnableBurst = false
+	limiter.config.EnableSliding = false
+	limiter.config.DefaultLimit = 2
+	limiter.config.DefaultWindow = time.Second
+
+	return limiter
+}
+
+// TestRateLimiterStartStop verifies lifecycle operations.
+func TestRateLimiterStartStop(t *testing.T) {
+	rl := newTestLimiter(t)
+
+	if err := rl.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if !rl.IsRunning() {
+		t.Fatalf("limiter should be running after Start")
+	}
+	if err := rl.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if rl.IsRunning() {
+		t.Fatalf("limiter should not be running after Stop")
+	}
+}
+
+// TestRateLimiterAllow ensures requests beyond the limit are denied.
+func TestRateLimiterAllow(t *testing.T) {
+	rl := newTestLimiter(t)
+	if err := rl.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer rl.Stop()
+
+	ctx := context.Background()
+	// First two requests should be allowed
+	for i := 0; i < 2; i++ {
+		allowed, _, err := rl.Allow(ctx, "client", 0, 0)
+		if err != nil {
+			t.Fatalf("Allow returned error: %v", err)
+		}
+		if !allowed {
+			t.Fatalf("request %d unexpectedly rejected", i)
+		}
+	}
+	// Third request should be rejected
+	allowed, _, err := rl.Allow(ctx, "client", 0, 0)
+	if err != nil {
+		t.Fatalf("Allow returned error: %v", err)
+	}
+	if allowed {
+		t.Fatalf("expected request to be rate limited")
+	}
+}

--- a/internal/storage/search/interface.go
+++ b/internal/storage/search/interface.go
@@ -370,9 +370,14 @@ func (e *SearchEngine) initializeIndices() error {
 	// Always initialize linear search as the basic index
 	e.indices[IndexTypeLinear] = e.linearSearch
 
-	// Initialize other indices based on configuration
-	// For now, we only have linear search implemented
-	// Other indices (IVF, HNSW, PQ, LSH) will be added in future iterations
+	// Initialize IVF index with default Go implementation
+	ivfIndex, err := NewIVFIndex(e.config, e.logger, e.metrics, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create ivf index: %w", err)
+	}
+	e.indices[IndexTypeIVF] = ivfIndex
+
+	// Other indices (HNSW, PQ, LSH) can be added here in the future
 
 	return nil
 }
@@ -798,7 +803,7 @@ func (e *SearchEngine) GetIndexTypeInfo(indexType IndexType) map[string]interfac
 		info["performance"] = "Fast, sublinear"
 		info["memory_usage"] = "Medium"
 		info["build_time"] = "Moderate"
-		info["implemented"] = false
+		info["implemented"] = true
 	case IndexTypeHNSW:
 		info["name"] = "HNSW"
 		info["description"] = "Hierarchical Navigable Small World graphs"

--- a/internal/storage/search/ivf.go
+++ b/internal/storage/search/ivf.go
@@ -1,0 +1,336 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	"vxdb/internal/config"
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
+
+	"go.uber.org/zap"
+)
+
+var (
+	ErrIVFNotBuilt = errors.New("ivf index not built")
+)
+
+// IVFConfig represents configuration for the IVF index
+// NumLists controls the number of inverted lists (clusters)
+// NProbe specifies how many lists to search during queries
+// DistanceMetric defines the metric used for clustering and search
+//
+// The config is intentionally lightweight so the underlying engine can be
+// swapped with CGO/FAISS based implementations without affecting callers.
+type IVFConfig struct {
+	NumLists       int            `yaml:"num_lists" json:"num_lists"`
+	NProbe         int            `yaml:"nprobe" json:"nprobe"`
+	DistanceMetric DistanceMetric `yaml:"distance_metric" json:"distance_metric"`
+}
+
+// DefaultIVFConfig returns default configuration for IVF index
+func DefaultIVFConfig() *IVFConfig {
+	return &IVFConfig{
+		NumLists:       1,
+		NProbe:         1,
+		DistanceMetric: DistanceEuclidean,
+	}
+}
+
+// IVFEngine defines the interface for IVF implementations. This allows the
+// search index to remain agnostic about the underlying algorithm and enables
+// swapping in CGO/FAISS engines later without changing call sites.
+type IVFEngine interface {
+	Build(vectors []*types.Vector, cfg *IVFConfig) error
+	Search(ctx context.Context, query *SearchQuery, cfg *IVFConfig) ([]*SearchResult, error)
+	Add(vectors []*types.Vector) error
+	Delete(ids []string) error
+	Clear() error
+	Stats() *IndexStats
+}
+
+// IVFIndex wraps an IVFEngine and exposes the SearchIndex interface expected by
+// the search engine. It delegates all heavy lifting to the configured engine.
+type IVFIndex struct {
+	config  *IVFConfig
+	engine  IVFEngine
+	status  IndexStatus
+	mu      sync.RWMutex
+	logger  *zap.Logger
+	metrics *metrics.StorageMetrics
+}
+
+// NewIVFIndex creates a new IVF index. If engine is nil, a simple in-memory
+// Go implementation is used. Callers can inject alternate engines (e.g. CGO
+// FAISS) to replace the default.
+func NewIVFIndex(cfg config.Config, logger *zap.Logger, metrics *metrics.StorageMetrics, engine IVFEngine) (*IVFIndex, error) {
+	ivfCfg := DefaultIVFConfig()
+	if cfg != nil {
+		if c, ok := cfg.Get("ivf"); ok {
+			if m, ok := c.(map[string]interface{}); ok {
+				if nl, ok := m["num_lists"].(int); ok {
+					ivfCfg.NumLists = nl
+				}
+				if np, ok := m["nprobe"].(int); ok {
+					ivfCfg.NProbe = np
+				}
+				if dm, ok := m["distance_metric"].(string); ok {
+					ivfCfg.DistanceMetric = DistanceMetric(dm)
+				}
+			}
+		}
+	}
+
+	if engine == nil {
+		engine = newGoIVFEngine(ivfCfg)
+	}
+
+	return &IVFIndex{
+		config:  ivfCfg,
+		engine:  engine,
+		status:  IndexStatusNotReady,
+		logger:  logger,
+		metrics: metrics,
+	}, nil
+}
+
+func (i *IVFIndex) GetType() IndexType { return IndexTypeIVF }
+
+func (i *IVFIndex) GetStatus() IndexStatus { return i.status }
+
+func (i *IVFIndex) GetConfig() *IndexConfig { return &IndexConfig{Type: IndexTypeIVF} }
+
+func (i *IVFIndex) GetStats() *IndexStats {
+	if i.engine != nil {
+		return i.engine.Stats()
+	}
+	return &IndexStats{Type: IndexTypeIVF, Status: i.status}
+}
+
+func (i *IVFIndex) Build(vectors []*types.Vector) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if err := i.engine.Build(vectors, i.config); err != nil {
+		i.status = IndexStatusError
+		return err
+	}
+	i.status = IndexStatusReady
+	return nil
+}
+
+func (i *IVFIndex) Update(vectors []*types.Vector) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if err := i.engine.Add(vectors); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *IVFIndex) Delete(ids []string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.engine.Delete(ids)
+}
+
+func (i *IVFIndex) Clear() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if err := i.engine.Clear(); err != nil {
+		return err
+	}
+	i.status = IndexStatusNotReady
+	return nil
+}
+
+func (i *IVFIndex) Search(ctx context.Context, query *SearchQuery) ([]*SearchResult, error) {
+	if query == nil {
+		return nil, ErrInvalidSearchQuery
+	}
+	if err := query.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidSearchQuery, err)
+	}
+	return i.engine.Search(ctx, query, i.config)
+}
+
+func (i *IVFIndex) BatchSearch(ctx context.Context, queries []*SearchQuery) ([][]*SearchResult, error) {
+	results := make([][]*SearchResult, len(queries))
+	for idx, q := range queries {
+		r, err := i.Search(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+		results[idx] = r
+	}
+	return results, nil
+}
+
+func (i *IVFIndex) Rebuild() error { return nil }
+
+func (i *IVFIndex) Optimize() error { return nil }
+
+func (i *IVFIndex) Validate() error { return nil }
+
+func (i *IVFIndex) Start() error { return nil }
+
+func (i *IVFIndex) Stop() error { return nil }
+
+func (i *IVFIndex) IsReady() bool { return i.status == IndexStatusReady }
+
+// ----------------- Default Go engine implementation --------------------
+
+type goIVFEngine struct {
+	cfg       *IVFConfig
+	centroids []*types.Vector
+	lists     map[int][]*types.Vector
+	mu        sync.RWMutex
+}
+
+func newGoIVFEngine(cfg *IVFConfig) *goIVFEngine {
+	return &goIVFEngine{
+		cfg:   cfg,
+		lists: make(map[int][]*types.Vector),
+	}
+}
+
+func (e *goIVFEngine) Build(vectors []*types.Vector, cfg *IVFConfig) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cfg = cfg
+	if cfg.NumLists <= 0 {
+		cfg.NumLists = 1
+	}
+	k := cfg.NumLists
+	if len(vectors) < k {
+		k = len(vectors)
+	}
+	e.centroids = make([]*types.Vector, k)
+	copy(e.centroids, vectors[:k])
+	e.lists = make(map[int][]*types.Vector, k)
+	for _, v := range vectors {
+		idx := e.assign(v)
+		e.lists[idx] = append(e.lists[idx], v)
+	}
+	return nil
+}
+
+func (e *goIVFEngine) assign(v *types.Vector) int {
+	best := 0
+	bestDist := math.MaxFloat64
+	for i, c := range e.centroids {
+		d, _ := v.Distance(c, string(e.cfg.DistanceMetric))
+		if d < bestDist {
+			bestDist = d
+			best = i
+		}
+	}
+	v.ClusterID = uint32(best)
+	return best
+}
+
+func (e *goIVFEngine) Search(ctx context.Context, query *SearchQuery, cfg *IVFConfig) ([]*SearchResult, error) {
+	e.mu.RLock()
+	centroids := e.centroids
+	lists := e.lists
+	e.mu.RUnlock()
+
+	if len(centroids) == 0 {
+		return nil, ErrIVFNotBuilt
+	}
+
+	type cd struct {
+		idx  int
+		dist float64
+	}
+	cds := make([]cd, len(centroids))
+	metric := cfg.DistanceMetric
+	if query.DistanceMetric != "" {
+		metric = query.DistanceMetric
+	}
+	for i, c := range centroids {
+		d, err := query.QueryVector.Distance(c, string(metric))
+		if err != nil {
+			return nil, err
+		}
+		cds[i] = cd{i, d}
+	}
+	sort.Slice(cds, func(i, j int) bool { return cds[i].dist < cds[j].dist })
+	nprobe := cfg.NProbe
+	if nprobe <= 0 || nprobe > len(cds) {
+		nprobe = len(cds)
+	}
+	candidates := make([]*types.Vector, 0)
+	for i := 0; i < nprobe; i++ {
+		candidates = append(candidates, lists[cds[i].idx]...)
+	}
+
+	results := make([]*SearchResult, 0, len(candidates))
+	for _, v := range candidates {
+		d, err := query.QueryVector.Distance(v, string(metric))
+		if err != nil {
+			return nil, err
+		}
+		if query.Threshold > 0 && float32(d) > query.Threshold {
+			continue
+		}
+		res := &SearchResult{Vector: v, Distance: d}
+		results = append(results, res)
+	}
+
+	sort.Slice(results, func(i, j int) bool { return results[i].Distance < results[j].Distance })
+	if query.Limit > 0 && len(results) > query.Limit {
+		results = results[:query.Limit]
+	}
+	return results, nil
+}
+
+func (e *goIVFEngine) Add(vectors []*types.Vector) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, v := range vectors {
+		idx := e.assign(v)
+		e.lists[idx] = append(e.lists[idx], v)
+	}
+	return nil
+}
+
+func (e *goIVFEngine) Delete(ids []string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	for idx, list := range e.lists {
+		filtered := list[:0]
+		for _, v := range list {
+			if _, ok := idSet[v.ID]; !ok {
+				filtered = append(filtered, v)
+			}
+		}
+		e.lists[idx] = filtered
+	}
+	return nil
+}
+
+func (e *goIVFEngine) Clear() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.centroids = nil
+	e.lists = make(map[int][]*types.Vector)
+	return nil
+}
+
+func (e *goIVFEngine) Stats() *IndexStats {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	var count int64
+	for _, l := range e.lists {
+		count += int64(len(l))
+	}
+	return &IndexStats{Type: IndexTypeIVF, Status: IndexStatusReady, VectorsCount: count}
+}

--- a/internal/storage/search/ivf_test.go
+++ b/internal/storage/search/ivf_test.go
@@ -1,0 +1,104 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
+
+	"go.uber.org/zap"
+)
+
+// helper to create IVFIndex with default Go engine
+func newTestIVFIndex(t *testing.T) *IVFIndex {
+	t.Helper()
+	m, _ := metrics.NewMetrics(nil)
+	sm := metrics.NewStorageMetrics(m, "test")
+	idx, err := NewIVFIndex(nil, zap.NewNop(), sm, nil)
+	if err != nil {
+		t.Fatalf("NewIVFIndex error: %v", err)
+	}
+	return idx
+}
+
+func TestIVFBuildAndSearch(t *testing.T) {
+	ivf := newTestIVFIndex(t)
+	ivf.config.NumLists = 3
+	ivf.config.NProbe = 1
+
+	vectors := []*types.Vector{
+		{ID: "a1", Data: []float32{0, 0}},
+		{ID: "b1", Data: []float32{10, 10}},
+		{ID: "c1", Data: []float32{-10, -10}},
+		{ID: "a2", Data: []float32{0.1, 0}},
+		{ID: "b2", Data: []float32{9.9, 10}},
+		{ID: "c2", Data: []float32{-9.9, -10}},
+	}
+
+	if err := ivf.Build(vectors); err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	q := &SearchQuery{
+		QueryVector:    &types.Vector{Data: []float32{0, 0}},
+		DistanceMetric: DistanceEuclidean,
+		Limit:          2,
+		IncludeVector:  true,
+	}
+	results, err := ivf.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Vector.ID != "a1" && results[0].Vector.ID != "a2" {
+		t.Fatalf("unexpected first result: %+v", results[0])
+	}
+}
+
+// mock engine to verify index modularity
+
+type mockIVFEngine struct {
+	built    bool
+	searched bool
+}
+
+func (m *mockIVFEngine) Build(v []*types.Vector, cfg *IVFConfig) error {
+	m.built = true
+	return nil
+}
+
+func (m *mockIVFEngine) Search(ctx context.Context, q *SearchQuery, cfg *IVFConfig) ([]*SearchResult, error) {
+	m.searched = true
+	return []*SearchResult{}, nil
+}
+
+func (m *mockIVFEngine) Add(v []*types.Vector) error { return nil }
+func (m *mockIVFEngine) Delete(ids []string) error   { return nil }
+func (m *mockIVFEngine) Clear() error                { return nil }
+func (m *mockIVFEngine) Stats() *IndexStats {
+	return &IndexStats{Type: IndexTypeIVF, Status: IndexStatusReady}
+}
+
+func TestIVFIndexCustomEngine(t *testing.T) {
+	eng := &mockIVFEngine{}
+	idx, err := NewIVFIndex(nil, zap.NewNop(), nil, eng)
+	if err != nil {
+		t.Fatalf("NewIVFIndex error: %v", err)
+	}
+	if err := idx.Build([]*types.Vector{}); err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+	if !eng.built {
+		t.Fatalf("custom engine Build not called")
+	}
+	q := &SearchQuery{QueryVector: &types.Vector{Data: []float32{0}}, DistanceMetric: DistanceEuclidean}
+	if _, err := idx.Search(context.Background(), q); err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if !eng.searched {
+		t.Fatalf("custom engine Search not called")
+	}
+}

--- a/internal/storage/search/linear_test.go
+++ b/internal/storage/search/linear_test.go
@@ -1,0 +1,111 @@
+package search
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"vxdb/internal/metrics"
+	"vxdb/internal/types"
+
+	"go.uber.org/zap"
+)
+
+// helper to create LinearSearch for tests
+func newTestLinearSearch(t *testing.T) *LinearSearch {
+	t.Helper()
+	m, _ := metrics.NewMetrics(nil)
+	sm := metrics.NewStorageMetrics(m, "test")
+	ls, err := NewLinearSearch(nil, zap.NewNop(), sm)
+	if err != nil {
+		t.Fatalf("NewLinearSearch error: %v", err)
+	}
+	return ls
+}
+
+func TestLinearSearchDistanceMetrics(t *testing.T) {
+	ls := newTestLinearSearch(t)
+	v1 := &types.Vector{ID: "a", Data: []float32{1, 0}}
+	v2 := &types.Vector{ID: "b", Data: []float32{0, 1}}
+
+	tests := []struct {
+		metric   DistanceMetric
+		expected float32
+	}{
+		{DistanceEuclidean, float32(math.Sqrt2)},
+		{DistanceCosine, 1.0},
+		{DistanceManhattan, 2.0},
+		{DistanceDotProduct, 0.0},
+		{DistanceHamming, 2.0},
+		{DistanceJaccard, 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.metric), func(t *testing.T) {
+			d, err := ls.calculateDistance(v1, v2, tt.metric)
+			if err != nil {
+				t.Fatalf("calculateDistance error: %v", err)
+			}
+			if math.Abs(float64(d-tt.expected)) > 1e-5 {
+				t.Fatalf("distance for %s = %v, want %v", tt.metric, d, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLinearSearchSearch(t *testing.T) {
+	ls := newTestLinearSearch(t)
+	vectors := []*types.Vector{
+		{ID: "v1", Data: []float32{0, 0}},
+		{ID: "v2", Data: []float32{1, 1}},
+		{ID: "v3", Data: []float32{2, 2}},
+	}
+	if err := ls.Build(vectors); err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	q := &SearchQuery{
+		QueryVector:    &types.Vector{Data: []float32{0, 0}},
+		DistanceMetric: DistanceEuclidean,
+		Limit:          2,
+		IncludeVector:  true,
+	}
+	results, err := ls.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Vector.ID != "v1" || results[0].Distance != 0 {
+		t.Fatalf("unexpected first result: %+v", results[0])
+	}
+	if results[1].Vector.ID != "v2" {
+		t.Fatalf("unexpected second result: %+v", results[1])
+	}
+}
+
+func TestLinearSearchThreshold(t *testing.T) {
+	ls := newTestLinearSearch(t)
+	vectors := []*types.Vector{
+		{ID: "v1", Data: []float32{0, 0}},
+		{ID: "v2", Data: []float32{1, 1}},
+	}
+	if err := ls.Build(vectors); err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	q := &SearchQuery{
+		QueryVector:    &types.Vector{Data: []float32{0, 0}},
+		DistanceMetric: DistanceEuclidean,
+		Threshold:      0.5,
+		IncludeVector:  true,
+	}
+	results, err := ls.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 1 || results[0].Vector.ID != "v1" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}


### PR DESCRIPTION
## Summary
- add pluggable IVFEngine and default Go-based implementation
- wire IVF index into search engine registry and mark as implemented
- test IVF search build, query, and custom engine injection

## Testing
- `go test ./internal/protocol/rate -run TestRateLimiter -count=1`
- `go test ./internal/storage/search -run TestLinearSearch -count=1`
- `go test ./internal/storage/search -run TestIVF -count=1`
- `go test ./... | head -n 200`


------
https://chatgpt.com/codex/tasks/task_b_68c1468d7e688323ad8949195c4f8c79