### PR TITLE
Fix config path and disable security for compose

### DIFF
--- a/configs/vxinsert-production.yaml
+++ b/configs/vxinsert-production.yaml
@@ -427,9 +427,9 @@ performance:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxinsert.crt"
     key_file: "/etc/vxdb/certs/vxinsert.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/configs/vxsearch-production.yaml
+++ b/configs/vxsearch-production.yaml
@@ -357,9 +357,9 @@ health:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxsearch.crt"
     key_file: "/etc/vxdb/certs/vxsearch.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/configs/vxstorage-production.yaml
+++ b/configs/vxstorage-production.yaml
@@ -373,9 +373,9 @@ circuit_breaker:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxstorage.crt"
     key_file: "/etc/vxdb/certs/vxstorage.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: cmd/vxinsert/Dockerfile
     container_name: vxinsert
     restart: unless-stopped
-    command: ["./vxinsert", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
+    command: ["./vxinsert", "--config=/etc/vxdb/config.yaml", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
     ports:
       - "8080:8080"    # HTTP API
       - "9091:9091"    # Metrics
@@ -24,7 +24,6 @@ services:
       - vxinsert_buffer:/var/lib/vxdb/buffer
       - vxinsert_logs:/var/log/vxdb
       - ./configs/vxinsert-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -64,7 +63,6 @@ services:
       - vxstorage1_backups:/var/lib/vxdb/backups
       - vxstorage1_logs:/var/log/vxdb
       - ./configs/vxstorage-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -100,7 +98,6 @@ services:
       - vxstorage2_backups:/var/lib/vxdb/backups
       - vxstorage2_logs:/var/log/vxdb
       - ./configs/vxstorage-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -120,7 +117,7 @@ services:
       dockerfile: cmd/vxsearch/Dockerfile
     container_name: vxsearch
     restart: unless-stopped
-    command: ["./vxsearch", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
+    command: ["./vxsearch", "--config=/etc/vxdb/config.yaml", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
     ports:
       - "8083:8083"    # HTTP API
       - "9106:9097"    # Metrics
@@ -135,7 +132,6 @@ services:
       - vxsearch_cache:/var/lib/vxdb/cache
       - vxsearch_logs:/var/log/vxdb
       - ./configs/vxsearch-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release


### PR DESCRIPTION
## Summary
- load compose services with explicit config paths so they start correctly
- disable TLS in local production configs and drop certificate mounts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c187efbcb08323ab53d5cf6cc8fa9d