### PR TITLE
Fix config path and disable security for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ VxDB is a distributed, high-throughput streaming vector database designed for re
 - Multi-protocol ingestion: WebSocket, HTTP, Kafka, Redis, gRPC
 - Hash-based cluster assignment and deterministic replication
 - Streaming-optimized, concurrent ingestion
+- For writes, vxinsert forwards to the appropriate vxstorage nodes; the
+  storage service is responsible for synchronizing data across the cluster
+  according to its replication settings
 
 ### vxstorage (Storage & Indexing)
 - Append-only segment files, in-memory buffer for fast writes
@@ -123,6 +126,19 @@ Run integration tests (requires additional services):
 ```
 go test -tags integration ./...
 ```
+
+## Code Graph
+
+A lightweight Go AST walker can generate a project-wide JSON graph of structs,
+functions (including their parameters and return types), and call
+relationships in this repository:
+
+```
+go run scripts/go_code_graph.go . > go_graph.json
+```
+
+The resulting file contains node and edge lists with function signatures and
+simple stats.
 
 ## Security
 - mTLS for inter-service

--- a/cmd/vxsearch/Dockerfile
+++ b/cmd/vxsearch/Dockerfile
@@ -66,4 +66,4 @@ ENV GIN_MODE=release
 ENV VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
 
 # Run the application
-CMD ["./vxsearch", "--config", "/etc/vxdb/config.yaml"]
+CMD ["./vxsearch"]

--- a/configs/vxinsert-production.yaml
+++ b/configs/vxinsert-production.yaml
@@ -427,9 +427,9 @@ performance:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxinsert.crt"
     key_file: "/etc/vxdb/certs/vxinsert.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/configs/vxsearch-production.yaml
+++ b/configs/vxsearch-production.yaml
@@ -357,9 +357,9 @@ health:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxsearch.crt"
     key_file: "/etc/vxdb/certs/vxsearch.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/configs/vxstorage-production.yaml
+++ b/configs/vxstorage-production.yaml
@@ -373,9 +373,9 @@ circuit_breaker:
 
 # Security configuration
 security:
-  enabled: true
+  enabled: false
   tls:
-    enabled: true
+    enabled: false
     cert_file: "/etc/vxdb/certs/vxstorage.crt"
     key_file: "/etc/vxdb/certs/vxstorage.key"
     ca_file: "/etc/vxdb/certs/ca.crt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: cmd/vxinsert/Dockerfile
     container_name: vxinsert
     restart: unless-stopped
-    command: ["./vxinsert", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
+    command: ["./vxinsert", "--config=/etc/vxdb/config.yaml", "--storage-addrs=vxstorage1:9096,vxstorage2:9096"]
     ports:
       - "8080:8080"    # HTTP API
       - "9091:9091"    # Metrics
@@ -24,7 +24,6 @@ services:
       - vxinsert_buffer:/var/lib/vxdb/buffer
       - vxinsert_logs:/var/log/vxdb
       - ./configs/vxinsert-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -64,7 +63,6 @@ services:
       - vxstorage1_backups:/var/lib/vxdb/backups
       - vxstorage1_logs:/var/log/vxdb
       - ./configs/vxstorage-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -100,7 +98,6 @@ services:
       - vxstorage2_backups:/var/lib/vxdb/backups
       - vxstorage2_logs:/var/log/vxdb
       - ./configs/vxstorage-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release
@@ -135,7 +132,6 @@ services:
       - vxsearch_cache:/var/lib/vxdb/cache
       - vxsearch_logs:/var/log/vxdb
       - ./configs/vxsearch-production.yaml:/etc/vxdb/config.yaml
-      - ./certs:/etc/vxdb/certs
     environment:
       - VXDB_CONFIG_FILE=/etc/vxdb/config.yaml
       - GIN_MODE=release

--- a/scripts/go_code_graph.go
+++ b/scripts/go_code_graph.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Node struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Type      string   `json:"type"`
+	File      string   `json:"file"`
+	Line      int      `json:"line"`
+	Params    []string `json:"params,omitempty"`
+	Results   []string `json:"results,omitempty"`
+	InDegree  int      `json:"in_degree"`
+	OutDegree int      `json:"out_degree"`
+}
+
+type Edge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Type   string `json:"type"`
+	File   string `json:"file"`
+	Line   int    `json:"line"`
+}
+
+type Graph struct {
+	Nodes []Node         `json:"nodes"`
+	Edges []Edge         `json:"edges"`
+	Stats map[string]int `json:"stats"`
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: go run go_code_graph.go [path]\n")
+	}
+	flag.Parse()
+	path := "."
+	if flag.NArg() > 0 {
+		path = flag.Arg(0)
+	}
+
+	g := analyze(path)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(g); err != nil {
+		fmt.Fprintln(os.Stderr, "encode error:", err)
+		os.Exit(1)
+	}
+}
+
+func analyze(root string) Graph {
+	nodes := map[string]*Node{}
+	edges := []Edge{}
+	fs := token.NewFileSet()
+
+	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		file, err := parser.ParseFile(fs, path, nil, 0)
+		if err != nil {
+			return nil
+		}
+		pkg := file.Name.Name
+
+		// structs and funcs
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.GenDecl:
+				if d.Tok == token.TYPE {
+					for _, spec := range d.Specs {
+						ts, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+						if _, ok := ts.Type.(*ast.StructType); ok {
+							id := pkg + "." + ts.Name.Name
+							pos := fs.Position(ts.Pos())
+							nodes[id] = &Node{ID: id, Label: ts.Name.Name, Type: "struct", File: rel, Line: pos.Line}
+						}
+					}
+				}
+			case *ast.FuncDecl:
+				id := funcID(pkg, d)
+				pos := fs.Position(d.Pos())
+				ntype := "function"
+				if d.Recv != nil {
+					ntype = "method"
+				}
+				params := fieldTypes(d.Type.Params, fs)
+				results := fieldTypes(d.Type.Results, fs)
+				nodes[id] = &Node{ID: id, Label: d.Name.Name, Type: ntype, File: rel, Line: pos.Line, Params: params, Results: results}
+
+				if d.Body != nil {
+					ast.Inspect(d.Body, func(n ast.Node) bool {
+						call, ok := n.(*ast.CallExpr)
+						if !ok {
+							return true
+						}
+						target := callName(pkg, call)
+						if target == "" {
+							return true
+						}
+						p := fs.Position(call.Pos())
+						edges = append(edges, Edge{Source: id, Target: target, Type: "calls", File: rel, Line: p.Line})
+						nodes[id].OutDegree++
+						if tgt, ok := nodes[target]; ok {
+							tgt.InDegree++
+						}
+						return true
+					})
+				}
+			}
+		}
+		return nil
+	})
+
+	// build lists and stats
+	nodeList := []Node{}
+	stats := map[string]int{"structs": 0, "functions": 0, "methods": 0}
+	for _, n := range nodes {
+		nodeList = append(nodeList, *n)
+		stats[n.Type+"s"]++
+	}
+	stats["total_nodes"] = len(nodeList)
+	stats["total_edges"] = len(edges)
+
+	return Graph{Nodes: nodeList, Edges: edges, Stats: stats}
+}
+
+func funcID(pkg string, f *ast.FuncDecl) string {
+	if f.Recv == nil {
+		return pkg + "." + f.Name.Name
+	}
+	recv := "unknown"
+	if len(f.Recv.List) > 0 {
+		switch t := f.Recv.List[0].Type.(type) {
+		case *ast.Ident:
+			recv = t.Name
+		case *ast.StarExpr:
+			if id, ok := t.X.(*ast.Ident); ok {
+				recv = id.Name
+			}
+		}
+	}
+	return pkg + "." + recv + "." + f.Name.Name
+}
+
+func callName(pkg string, c *ast.CallExpr) string {
+	switch fn := c.Fun.(type) {
+	case *ast.Ident:
+		return pkg + "." + fn.Name
+	case *ast.SelectorExpr:
+		if id, ok := fn.X.(*ast.Ident); ok {
+			return id.Name + "." + fn.Sel.Name
+		}
+		return "*." + fn.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func fieldTypes(fl *ast.FieldList, fs *token.FileSet) []string {
+	if fl == nil {
+		return nil
+	}
+	types := []string{}
+	for _, f := range fl.List {
+		types = append(types, exprString(f.Type, fs))
+	}
+	return types
+}
+
+func exprString(e ast.Expr, fs *token.FileSet) string {
+	var buf bytes.Buffer
+	printer.Fprint(&buf, fs, e)
+	return buf.String()
+}


### PR DESCRIPTION
## Summary
- load compose services with explicit config paths so they start correctly
- disable TLS in local production configs and drop certificate mounts
- remove unsupported --config flag from vxsearch compose command
- clarify that vxinsert forwards writes while vxstorage handles cluster sync
- run vxsearch image without unsupported --config flag
- add Go code graph analyzer and document usage
- include parameter and return types in generated code graph for project-wide analysis

## Testing
- `go test ./...`
- `go run scripts/go_code_graph.go . > /tmp/go_graph.json`


------
https://chatgpt.com/codex/tasks/task_b_68c187efbcb08323ab53d5cf6cc8fa9d